### PR TITLE
feat(config): rename spec dir when updating spec-dir-name

### DIFF
--- a/cli/src/lib/config/configManager.js
+++ b/cli/src/lib/config/configManager.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const fs = require('fs').promises;
 const YAML = require('yaml');
+const logger = require('../utils/logger');
 
 const CONFIG_FILE_NAME = 'r3nd.yaml';
 
@@ -73,6 +74,44 @@ class ConfigManager {
    */
   async set(key, value) {
     const config = await this.load();
+
+    // If changing the spec dir name, attempt to rename the directory in the working tree
+    if (key === 'spec-dir-name') {
+      const oldName = config['spec-dir-name'] || 'r3nd';
+      const newName = value;
+
+      // Only attempt rename when the name actually changes
+      if (oldName !== newName) {
+        const oldPath = path.join(this.cwd, oldName);
+        const newPath = path.join(this.cwd, newName);
+
+        try {
+          const stat = await fs.stat(oldPath);
+            if (stat && stat.isDirectory()) {
+            // If target exists, throw so consumer can handle
+            try {
+              await fs.access(newPath);
+              throw new Error(`Target directory already exists: ${newName}`);
+            } catch (err) {
+              if (err && err.code === 'ENOENT') {
+                // safe to rename
+                await fs.rename(oldPath, newPath);
+                logger.info(`✓ Renamed spec directory: ${oldName} -> ${newName}`);
+              } else {
+                // rethrow unexpected errors
+                throw err;
+              }
+            }
+          }
+        } catch (err) {
+          // If old path doesn't exist, ignore and continue; otherwise rethrow
+          if (!(err && err.code === 'ENOENT')) {
+            throw new Error(`Failed to rename spec dir: ${err.message}`);
+          }
+        }
+      }
+    }
+
     config[key] = value;
     await this.save(config);
   }

--- a/cli/src/lib/config/configManager.spec.js
+++ b/cli/src/lib/config/configManager.spec.js
@@ -223,4 +223,77 @@ describe('ConfigManager', () => {
       expect(dirName).toBe('r3nd');
     });
   });
+
+  describe('spec-dir rename on set', () => {
+    it('should rename existing spec directory when changing spec-dir-name', async () => {
+      // Create the default directory 'r3nd'
+      const oldDir = path.join(tempDir, 'r3nd');
+      await fs.mkdir(oldDir);
+
+      await configManager.set('spec-dir-name', 'specs');
+
+      // Ensure old directory no longer exists and new directory exists
+      let existsOld = true;
+      try {
+        await fs.access(oldDir);
+      } catch (err) {
+        if (err && err.code === 'ENOENT') existsOld = false;
+      }
+
+      const newDir = path.join(tempDir, 'specs');
+      let existsNew = false;
+      try {
+        await fs.access(newDir);
+        existsNew = true;
+      } catch (err) {
+        existsNew = false;
+      }
+
+      expect(existsOld).toBe(false);
+      expect(existsNew).toBe(true);
+
+      // And config persisted
+      const value = await configManager.get('spec-dir-name');
+      expect(value).toBe('specs');
+    });
+
+    it('should log message when rename succeeds', async () => {
+      const oldDir = path.join(tempDir, 'r3nd');
+      await fs.mkdir(oldDir);
+
+      // Spy on logger
+      const logger = require('../utils/logger');
+      const spy = jest.spyOn(logger, 'info').mockImplementation(() => {});
+
+      await configManager.set('spec-dir-name', 'specs');
+
+      expect(spy).toHaveBeenCalledWith(expect.stringContaining('Renamed spec directory'));
+      spy.mockRestore();
+    });
+
+    it('should throw when target directory already exists', async () => {
+      const oldDir = path.join(tempDir, 'r3nd');
+      const targetDir = path.join(tempDir, 'specs');
+      await fs.mkdir(oldDir);
+      await fs.mkdir(targetDir);
+
+      await expect(configManager.set('spec-dir-name', 'specs')).rejects.toThrow('Target directory already exists');
+
+      // original directories remain
+      await expect(fs.access(oldDir)).resolves.toBeUndefined();
+      await expect(fs.access(targetDir)).resolves.toBeUndefined();
+    });
+
+    it('should set value even if old directory does not exist', async () => {
+      // Ensure no old directory present
+      const oldDir = path.join(tempDir, 'r3nd');
+      try {
+        await fs.rm(oldDir, { recursive: true, force: true });
+      } catch (err) {}
+
+      await expect(configManager.set('spec-dir-name', 'specs')).resolves.toBeUndefined();
+      const value = await configManager.get('spec-dir-name');
+      expect(value).toBe('specs');
+    });
+  });
 });

--- a/cli/src/lib/initService.js
+++ b/cli/src/lib/initService.js
@@ -5,7 +5,7 @@ const YAML = require('yaml');
 
 const { GitHubClient } = require('./github/githubClient');
 const { writeBuffer, ensureDir } = require('./fs/fileWriter');
-const { askInitOptions, askSeedRepo } = require('./ui/prompts');
+const { askInitOptions, askSeedRepo, askSpecDirName } = require('./ui/prompts');
 const { ConfigManager } = require('./config/configManager');
 const { resolveTemplate, createGitHubFileReader } = require('./templateResolver');
 const { rewriteSpecDirBuffer, rewriteSpecDirContent } = require('./utils/specDirRewrite');
@@ -73,7 +73,6 @@ async function runInit(opts = {}, deps = {}) {
   
   // Initialize config manager
   const configManager = new ConfigManager(cwd);
-  const specDirName = await configManager.getSpecDirName();
   
   // Check if seed-repo is configured, prompt if not
   let seedRepo = await configManager.get('seed-repo');
@@ -82,6 +81,23 @@ async function runInit(opts = {}, deps = {}) {
     seedRepo = await askSeedRepo(null, nonInteractive);
     await configManager.set('seed-repo', seedRepo);
     logger.info(`✓ Configured seed-repo: ${seedRepo}\n`);
+  }
+
+  // Check if spec-dir-name is configured, prompt if not
+  let specDirName = await configManager.get('spec-dir-name');
+  if (!specDirName) {
+    logger.info('No spec directory name configured.');
+    specDirName = await askSpecDirName(null, nonInteractive);
+    await configManager.set('spec-dir-name', specDirName);
+    logger.info(`✓ Configured spec-dir-name: ${specDirName}\n`);
+  } else {
+    // Even if configured, ask the user to confirm or change it during init
+    const confirmedSpecDirName = await askSpecDirName(specDirName, nonInteractive);
+    if (confirmedSpecDirName !== specDirName) {
+      await configManager.set('spec-dir-name', confirmedSpecDirName);
+      specDirName = confirmedSpecDirName;
+      logger.info(`✓ Updated spec-dir-name: ${specDirName}\n`);
+    }
   }
 
   const githubClient = deps.githubClient || new GitHubClient({ cwd });
@@ -104,6 +120,18 @@ async function runInit(opts = {}, deps = {}) {
   // Fetch file tree from GitHub
   logger.info('Fetching file list from GitHub (seed repo)...');
   const tree = await githubClient.getTree();
+  
+  // Fetch seed repo's spec-dir-name configuration
+  let seedSpecDirName = 'rnd'; // default for backwards compatibility
+  try {
+    const configBuffer = await githubClient.fetchRaw('r3nd.yaml');
+    const configContent = configBuffer.toString('utf-8');
+    const seedConfig = YAML.parse(configContent) || {};
+    seedSpecDirName = seedConfig['spec-dir-name'] || 'rnd';
+  } catch (err) {
+    // If r3nd.yaml doesn't exist in seed repo, use default 'rnd'
+    logger.debug('No r3nd.yaml in seed repo, using default "rnd"');
+  }
 
   // Always copy common files
   const commonFiles = [
@@ -127,24 +155,24 @@ async function runInit(opts = {}, deps = {}) {
     }
   }
 
-  // Copy platform-agnostic agent personas from rnd/agents
-  await copyAgentPersonas(cwd, tree, githubClient, specDirName);
+  // Copy platform-agnostic agent personas from seed repo
+  await copyAgentPersonas(cwd, tree, githubClient, specDirName, seedSpecDirName);
 
   // Process selected options (these are optional)
   if (selectedOptions.includes('github')) {
     await copyGitHubWorkflows(cwd, tree, githubClient);
     // Compose GitHub Copilot agent files from wrappers + personas
-    await composeAgentFiles(cwd, tree, githubClient, '.github/agents', '.agent.md', specDirName);
+  await composeAgentFiles(cwd, tree, githubClient, '.github/agents', '.agent.md', specDirName, seedSpecDirName);
   }
 
   if (selectedOptions.includes('cursor')) {
     // Compose Cursor command files from wrappers + personas
-    await composeAgentFiles(cwd, tree, githubClient, '.cursor/commands', '.md', specDirName);
+  await composeAgentFiles(cwd, tree, githubClient, '.cursor/commands', '.md', specDirName, seedSpecDirName);
   }
 
   if (selectedOptions.includes('vscode')) {
     // Compose VSCode chat mode files from wrappers + personas
-    await composeAgentFiles(cwd, tree, githubClient, '.github/chatmodes', '.chatmode.md', specDirName);
+  await composeAgentFiles(cwd, tree, githubClient, '.github/chatmodes', '.chatmode.md', specDirName, seedSpecDirName);
   }
 
   // Also copy templates if any option was selected
@@ -180,13 +208,20 @@ async function copyGitHubWorkflows(cwd, tree, githubClient) {
 }
 
 /**
- * Copy platform-agnostic agent persona files from rnd/agents
+ * Copy platform-agnostic agent persona files from seed repo
+ * @param {string} cwd - Current working directory
+ * @param {Array} tree - GitHub tree
+ * @param {GitHubClient} githubClient - GitHub client instance
+ * @param {string} specDirName - Target spec directory name (e.g., 'r3nd', 'rnd')
+ * @param {string} seedSpecDirName - Seed repo's spec directory name (e.g., 'r3nd', 'rnd')
  */
-async function copyAgentPersonas(cwd, tree, githubClient, specDirName) {
+async function copyAgentPersonas(cwd, tree, githubClient, specDirName, seedSpecDirName) {
   logger.info('\n🤖 Copying agent personas...');
   
+  // Read from seed repo's configured spec directory
+  const seedAgentsPath = `${seedSpecDirName}/agents/`;
   const agentFiles = tree.filter(item => 
-    item.type === 'blob' && item.path.startsWith('rnd/agents/') && item.path.endsWith('.md')
+    item.type === 'blob' && item.path.startsWith(seedAgentsPath) && item.path.endsWith('.md')
   );
 
   if (agentFiles.length === 0) {
@@ -197,9 +232,14 @@ async function copyAgentPersonas(cwd, tree, githubClient, specDirName) {
   for (const file of agentFiles) {
     try {
       const buffer = await githubClient.fetchRaw(file.path);
-      const rewritten = rewriteSpecDirBuffer(buffer, file.path, ['rnd'], specDirName);
-      await writeBuffer(cwd, file.path, rewritten.buffer, { overwrite: true });
-      logger.info(`  Copied: ${file.path}`);
+      // Map from seed repo path to local path
+      const relativePath = file.path.substring(seedAgentsPath.length);
+      const localPath = `${specDirName}/agents/${relativePath}`;
+
+      // Rewrite any spec-dir references from the seed repo to the local spec dir
+      const rewritten = rewriteSpecDirBuffer(buffer, file.path, [seedSpecDirName], specDirName);
+      await writeBuffer(cwd, localPath, rewritten.buffer, { overwrite: true });
+      logger.info(`  Copied: ${localPath}`);
     } catch (err) {
       logger.error(`  Failed to copy ${file.path}:`, err && err.message ? err.message : err);
     }
@@ -207,14 +247,16 @@ async function copyAgentPersonas(cwd, tree, githubClient, specDirName) {
 }
 
 /**
- * Compose agent files from platform-specific wrappers and rnd/agents personas
+ * Compose agent files from platform-specific wrappers and agent personas from seed repo
  * @param {string} cwd - Current working directory
  * @param {Array} tree - GitHub tree
  * @param {GitHubClient} githubClient - GitHub client instance
  * @param {string} wrapperDir - Directory containing wrapper templates (e.g., '.github/agents')
  * @param {string} extension - File extension to filter (e.g., '.agent.md')
+ * @param {string} specDirName - Spec directory name for local references (e.g., 'r3nd', 'rnd')
+ * @param {string} seedSpecDirName - Seed repo's spec directory name (e.g., 'r3nd', 'rnd')
  */
-async function composeAgentFiles(cwd, tree, githubClient, wrapperDir, extension, specDirName) {
+async function composeAgentFiles(cwd, tree, githubClient, wrapperDir, extension, specDirName, seedSpecDirName) {
   const platformName = wrapperDir === '.github/agents' ? 'GitHub Copilot' : 
                        wrapperDir === '.cursor/commands' ? 'Cursor' : 'VSCode';
   logger.info(`\n📝 Composing ${platformName} agent files...`);
@@ -234,15 +276,23 @@ async function composeAgentFiles(cwd, tree, githubClient, wrapperDir, extension,
   // Build a cache of all files from tree for template resolution
   const fileCache = new Map();
   
-  // Fetch all rnd/agents files into cache
+  // Fetch all agent files from seed repo's configured spec directory
+  const seedAgentsPath = `${seedSpecDirName}/agents/`;
   const personaFiles = tree.filter(item => 
-    item.type === 'blob' && item.path.startsWith('rnd/agents/')
+    item.type === 'blob' && item.path.startsWith(seedAgentsPath)
   );
   
   for (const file of personaFiles) {
     try {
       const buffer = await githubClient.fetchRaw(file.path);
+      
+      // Store in cache with both seed repo path and local path for resolution flexibility
       fileCache.set(file.path, buffer);
+      
+      // Also map to local path so templates can reference either rnd/agents or specDirName/agents
+      const relativePath = file.path.substring(seedAgentsPath.length);
+      const localPath = `${specDirName}/agents/${relativePath}`;
+      fileCache.set(localPath, buffer);
     } catch (err) {
       logger.error(`  Failed to cache ${file.path}:`, err && err.message ? err.message : err);
     }
@@ -261,10 +311,20 @@ async function composeAgentFiles(cwd, tree, githubClient, wrapperDir, extension,
       
       // Resolve template placeholders
       const composedContent = await resolveTemplate(wrapperContent, fileReader);
-      const rewritten = rewriteSpecDirContent(composedContent, ['rnd'], specDirName);
+      const rewritten = rewriteSpecDirContent(composedContent, [seedSpecDirName], specDirName);
+
+      // Replace spec directory references from seed repo to local spec directory
+      // This handles cases where the seed repo uses a different spec-dir-name (e.g., 'rnd')
+      // and the local repo uses a different one (e.g., 'r3nd')
+      let finalContent = rewritten.content;
+      if (seedSpecDirName !== specDirName) {
+        // Replace patterns like "rnd/agents/", "rnd/product_specs/", "rnd/tech_specs/", "rnd/build_plans/"
+        const specDirPattern = new RegExp(`\\b${seedSpecDirName}/`, 'g');
+        finalContent = finalContent.replace(specDirPattern, `${specDirName}/`);
+      }
       
       // Write composed file
-      await writeBuffer(cwd, file.path, Buffer.from(rewritten.content, 'utf-8'), { overwrite: true });
+      await writeBuffer(cwd, file.path, Buffer.from(finalContent, 'utf-8'), { overwrite: true });
       logger.info(`  Composed: ${file.path}`);
     } catch (err) {
       logger.error(`  Failed to compose ${file.path}:`, err && err.message ? err.message : err);

--- a/cli/src/lib/initService.spec.js
+++ b/cli/src/lib/initService.spec.js
@@ -1,7 +1,8 @@
 // Mock inquirer to avoid ESM import issues
 jest.mock('./ui/prompts', () => ({
   askInitOptions: jest.fn().mockResolvedValue(['github', 'cursor', 'vscode']),
-  askSeedRepo: jest.fn().mockResolvedValue('leandronoijo/r3nd@develop')
+  askSeedRepo: jest.fn().mockResolvedValue('leandronoijo/r3nd@develop'),
+  askSpecDirName: jest.fn().mockResolvedValue('r3nd')
 }));
 
 // Mock config manager

--- a/cli/src/lib/scaffoldService.js
+++ b/cli/src/lib/scaffoldService.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const YAML = require('yaml');
 
 const { GitHubClient } = require('./github/githubClient');
 const { mapDestination } = require('./overlays/overlayRegistry');
@@ -122,7 +123,7 @@ async function runScaffold(opts = {}, deps = {}) {
     logger.info('Scaffolding complete.');
   }
 
-  async function ensureSeedFiles(files) {
+  async function ensureSeedFiles(files, seedSpecDirName = 'rnd') {
     const missing = [];
     for (const remotePath of files) {
       const rel = mapDestination(remotePath, backend, frontend, specDirName) || remotePath;
@@ -136,7 +137,7 @@ async function runScaffold(opts = {}, deps = {}) {
     for (const item of missing) {
       try {
         const buffer = await githubClient.fetchRaw(item.remotePath);
-        const rewritten = rewriteSpecDirBuffer(buffer, item.rel, ['rnd'], specDirName);
+        const rewritten = rewriteSpecDirBuffer(buffer, item.rel, [seedSpecDirName], specDirName);
         await writeBuffer(cwd, item.rel, rewritten.buffer, { overwrite: false });
         logger.info(`Copied: ${item.remotePath} -> ${item.rel}`);
       } catch (err) {
@@ -150,9 +151,22 @@ async function runScaffold(opts = {}, deps = {}) {
     logger.info('Ensuring all agent persona files are present...');
     const tree = await githubClient.getTree();
     
-    // First, ensure rnd/agents persona files
+    // Fetch seed repo's spec-dir-name configuration
+    let seedSpecDirName = 'rnd'; // default for backwards compatibility
+    try {
+      const configBuffer = await githubClient.fetchRaw('r3nd.yaml');
+      const configContent = configBuffer.toString('utf-8');
+      const seedConfig = YAML.parse(configContent) || {};
+      seedSpecDirName = seedConfig['spec-dir-name'] || 'rnd';
+    } catch (err) {
+      // If r3nd.yaml doesn't exist in seed repo, use default 'rnd'
+      logger.debug('No r3nd.yaml in seed repo, using default "rnd"');
+    }
+    
+    // First, ensure agent persona files from seed repo
+    const seedAgentsPath = `${seedSpecDirName}/agents/`;
     const personaFiles = tree.filter(item => 
-      item.type === 'blob' && item.path.startsWith('rnd/agents/') && item.path.endsWith('.md')
+      item.type === 'blob' && item.path.startsWith(seedAgentsPath) && item.path.endsWith('.md')
     );
     
     if (personaFiles.length === 0) {
@@ -161,7 +175,7 @@ async function runScaffold(opts = {}, deps = {}) {
     }
 
     const personaPaths = personaFiles.map(f => f.path);
-    await ensureSeedFiles(personaPaths);
+    await ensureSeedFiles(personaPaths, seedSpecDirName);
     
     // Then, compose platform-specific agent files
     // Check which platforms are configured/exist in the project
@@ -196,8 +210,13 @@ async function runScaffold(opts = {}, deps = {}) {
           const wrapperBuffer = await githubClient.fetchRaw(file.path);
           const wrapperContent = wrapperBuffer.toString('utf-8');
           const composedContent = await resolveTemplate(wrapperContent, fileReader);
-          const rewritten = rewriteSpecDirContent(composedContent, ['rnd'], specDirName);
-          await writeBuffer(cwd, file.path, Buffer.from(rewritten.content, 'utf-8'), { overwrite: true });
+          const rewritten = rewriteSpecDirContent(composedContent, [seedSpecDirName], specDirName);
+          let finalContent = rewritten.content;
+          if (seedSpecDirName !== specDirName) {
+            const specDirPattern = new RegExp(`\\b${seedSpecDirName}/`, 'g');
+            finalContent = finalContent.replace(specDirPattern, `${specDirName}/`);
+          }
+          await writeBuffer(cwd, file.path, Buffer.from(finalContent, 'utf-8'), { overwrite: true });
           logger.info(`  Composed: ${file.path}`);
         } catch (err) {
           logger.error(`  Failed to compose ${file.path}:`, err && err.message ? err.message : err);
@@ -216,8 +235,13 @@ async function runScaffold(opts = {}, deps = {}) {
           const wrapperBuffer = await githubClient.fetchRaw(file.path);
           const wrapperContent = wrapperBuffer.toString('utf-8');
           const composedContent = await resolveTemplate(wrapperContent, fileReader);
-          const rewritten = rewriteSpecDirContent(composedContent, ['rnd'], specDirName);
-          await writeBuffer(cwd, file.path, Buffer.from(rewritten.content, 'utf-8'), { overwrite: true });
+          const rewritten = rewriteSpecDirContent(composedContent, [seedSpecDirName], specDirName);
+          let finalContent = rewritten.content;
+          if (seedSpecDirName !== specDirName) {
+            const specDirPattern = new RegExp(`\\b${seedSpecDirName}/`, 'g');
+            finalContent = finalContent.replace(specDirPattern, `${specDirName}/`);
+          }
+          await writeBuffer(cwd, file.path, Buffer.from(finalContent, 'utf-8'), { overwrite: true });
           logger.info(`  Composed: ${file.path}`);
         } catch (err) {
           logger.error(`  Failed to compose ${file.path}:`, err && err.message ? err.message : err);
@@ -236,8 +260,13 @@ async function runScaffold(opts = {}, deps = {}) {
           const wrapperBuffer = await githubClient.fetchRaw(file.path);
           const wrapperContent = wrapperBuffer.toString('utf-8');
           const composedContent = await resolveTemplate(wrapperContent, fileReader);
-          const rewritten = rewriteSpecDirContent(composedContent, ['rnd'], specDirName);
-          await writeBuffer(cwd, file.path, Buffer.from(rewritten.content, 'utf-8'), { overwrite: true });
+          const rewritten = rewriteSpecDirContent(composedContent, [seedSpecDirName], specDirName);
+          let finalContent = rewritten.content;
+          if (seedSpecDirName !== specDirName) {
+            const specDirPattern = new RegExp(`\\b${seedSpecDirName}/`, 'g');
+            finalContent = finalContent.replace(specDirPattern, `${specDirName}/`);
+          }
+          await writeBuffer(cwd, file.path, Buffer.from(finalContent, 'utf-8'), { overwrite: true });
           logger.info(`  Composed: ${file.path}`);
         } catch (err) {
           logger.error(`  Failed to compose ${file.path}:`, err && err.message ? err.message : err);

--- a/cli/src/lib/ui/prompts.js
+++ b/cli/src/lib/ui/prompts.js
@@ -290,4 +290,40 @@ async function askSeedRepo(currentValue = null, nonInteractive = false) {
   return res.seedRepo.trim();
 }
 
-module.exports = { chooseBackend, chooseFrontend, askLLMChoice, confirmRunNow, confirmSavePrompts, askRemoteOrigin, askBugDescription, askFeatureDescription, askBugfixLLMChoice, confirmBuildPlan, askAnalyseAgent, buildAgentChoices, chooseFile, askInitOptions, askUpdateOptions, askSeedRepo };
+/**
+ * Prompt user for spec directory name configuration
+ * @param {string} currentValue - Current spec-dir-name value if any
+ * @param {boolean} nonInteractive - If true, returns default value
+ * @returns {Promise<string>} Spec directory name (e.g., 'r3nd', 'rnd', 'specs')
+ */
+async function askSpecDirName(currentValue = null, nonInteractive = false) {
+  const defaultValue = currentValue || 'r3nd';
+  
+  if (nonInteractive) return defaultValue;
+  
+  const res = await prompt([{
+    type: 'input',
+    name: 'specDirName',
+    message: 'Enter spec directory name (where agents and specs will be stored):',
+    default: defaultValue,
+    validate: (input) => {
+      const trimmed = input.trim();
+      if (!trimmed) return 'Spec directory name is required';
+      
+      // Validate it's a valid directory name (no slashes, no special chars that break paths)
+      if (trimmed.includes('/') || trimmed.includes('\\')) {
+        return 'Directory name cannot contain slashes';
+      }
+      
+      if (!/^[a-zA-Z0-9_.-]+$/.test(trimmed)) {
+        return 'Directory name can only contain letters, numbers, dots, dashes, and underscores';
+      }
+      
+      return true;
+    }
+  }]);
+  
+  return res.specDirName.trim();
+}
+
+module.exports = { chooseBackend, chooseFrontend, askLLMChoice, confirmRunNow, confirmSavePrompts, askRemoteOrigin, askBugDescription, askFeatureDescription, askBugfixLLMChoice, confirmBuildPlan, askAnalyseAgent, buildAgentChoices, chooseFile, askInitOptions, askUpdateOptions, askSeedRepo, askSpecDirName };

--- a/cli/src/lib/updateService.js
+++ b/cli/src/lib/updateService.js
@@ -1,9 +1,10 @@
 const path = require('path');
 const fs = require('fs').promises;
+const YAML = require('yaml');
 
 const { GitHubClient } = require('./github/githubClient');
 const { writeBuffer, ensureDir } = require('./fs/fileWriter');
-const { askUpdateOptions, askSeedRepo } = require('./ui/prompts');
+const { askUpdateOptions, askSeedRepo, askSpecDirName } = require('./ui/prompts');
 const { resolveTemplate, createGitHubFileReader } = require('./templateResolver');
 const { ConfigManager } = require('./config/configManager');
 const { rewriteSpecDirBuffer, rewriteSpecDirContent } = require('./utils/specDirRewrite');
@@ -25,6 +26,7 @@ async function runUpdate(opts = {}, deps = {}) {
     logger.info(`✓ Configured seed-repo: ${seedRepo}\n`);
   }
 
+  // Get spec directory name from config (defaults to 'r3nd')
   const specDirName = await configManager.getSpecDirName();
 
   const githubClient = deps.githubClient || new GitHubClient({ cwd });
@@ -50,27 +52,40 @@ async function runUpdate(opts = {}, deps = {}) {
   logger.info('Fetching file list from GitHub (seed repo)...');
   const tree = await githubClient.getTree();
 
+  // Fetch seed repo's spec-dir-name configuration
+  let seedSpecDirName = 'rnd'; // default for backwards compatibility
+  try {
+    const configBuffer = await githubClient.fetchRaw('r3nd.yaml');
+    const configContent = configBuffer.toString('utf-8');
+    const seedConfig = YAML.parse(configContent) || {};
+    seedSpecDirName = seedConfig['spec-dir-name'] || 'rnd';
+  } catch (err) {
+    // If r3nd.yaml doesn't exist in seed repo, use default 'rnd'
+    logger.debug('No r3nd.yaml in seed repo, using default "rnd"');
+  }
+
   // Process selected options
   if (selectedOptions.includes('templates')) {
-    await updateTemplates(cwd, tree, githubClient, specDirName);
+    await updateTemplates(cwd, tree, githubClient, specDirName, seedSpecDirName);
   }
 
   if (selectedOptions.includes('agents')) {
-    await updateAgentPersonas(cwd, tree, githubClient, specDirName);
+    await updateAgentPersonas(cwd, tree, githubClient, specDirName, seedSpecDirName);
   }
 
   if (selectedOptions.includes('github')) {
     await updateGitHubWorkflows(cwd, tree, githubClient);
     // Also update composed GitHub Copilot agent files
-    await updateComposedAgents(cwd, tree, githubClient, '.github/agents', '.agent.md', specDirName);
+    await updateComposedAgents(cwd, tree, githubClient, '.github/agents', '.agent.md', specDirName, seedSpecDirName);
   }
 
   if (selectedOptions.includes('cursor')) {
-    await updateComposedAgents(cwd, tree, githubClient, '.cursor/commands', '.md', specDirName);
+    await updateComposedAgents(cwd, tree, githubClient, '.cursor/commands', '.md', specDirName, seedSpecDirName);
   }
 
   if (selectedOptions.includes('vscode')) {
-    await updateComposedAgents(cwd, tree, githubClient, '.github/chatmodes', '.chatmode.md', specDirName);
+    await updateComposedAgents(cwd, tree, githubClient, '.github/chatmodes', '.chatmode.md', specDirName, seedSpecDirName);
+  }
   }
 
   logger.info('\nUpdate complete.');
@@ -79,7 +94,7 @@ async function runUpdate(opts = {}, deps = {}) {
 /**
  * Update template files
  */
-async function updateTemplates(cwd, tree, githubClient, specDirName) {
+async function updateTemplates(cwd, tree, githubClient, specDirName, seedSpecDirName = 'rnd') {
   logger.info('\n📋 Updating templates...');
   
   const templateFiles = tree.filter(item => 
@@ -94,7 +109,7 @@ async function updateTemplates(cwd, tree, githubClient, specDirName) {
   for (const file of templateFiles) {
     try {
       const buffer = await githubClient.fetchRaw(file.path);
-      const rewritten = rewriteSpecDirBuffer(buffer, file.path, ['rnd'], specDirName);
+      const rewritten = rewriteSpecDirBuffer(buffer, file.path, [seedSpecDirName], specDirName);
       await writeBuffer(cwd, file.path, rewritten.buffer, { overwrite: true });
       logger.info(`  Updated: ${file.path}`);
     } catch (err) {
@@ -104,13 +119,20 @@ async function updateTemplates(cwd, tree, githubClient, specDirName) {
 }
 
 /**
- * Update agent persona files from rnd/agents
+ * Update agent persona files from seed repo to local repo
+ * @param {string} cwd - Current working directory
+ * @param {Array} tree - GitHub tree
+ * @param {GitHubClient} githubClient - GitHub client instance
+ * @param {string} specDirName - Local spec directory name (e.g., 'r3nd', 'rnd')
+ * @param {string} seedSpecDirName - Seed repo's spec directory name (e.g., 'r3nd', 'rnd')
  */
-async function updateAgentPersonas(cwd, tree, githubClient, specDirName) {
+async function updateAgentPersonas(cwd, tree, githubClient, specDirName, seedSpecDirName) {
   logger.info('\n🤖 Updating agent personas...');
   
+  // Read from seed repo's configured spec directory
+  const seedAgentsPath = `${seedSpecDirName}/agents/`;
   const agentFiles = tree.filter(item => 
-    item.type === 'blob' && item.path.startsWith('rnd/agents/') && item.path.endsWith('.md')
+    item.type === 'blob' && item.path.startsWith(seedAgentsPath) && item.path.endsWith('.md')
   );
 
   if (agentFiles.length === 0) {
@@ -119,11 +141,16 @@ async function updateAgentPersonas(cwd, tree, githubClient, specDirName) {
   }
 
   for (const file of agentFiles) {
-    try {
+        try {
       const buffer = await githubClient.fetchRaw(file.path);
-      const rewritten = rewriteSpecDirBuffer(buffer, file.path, ['rnd'], specDirName);
-      await writeBuffer(cwd, file.path, rewritten.buffer, { overwrite: true });
-      logger.info(`  Updated: ${file.path}`);
+      // Map from seed repo path to local path
+      const relativePath = file.path.substring(seedAgentsPath.length);
+      const localPath = `${specDirName}/agents/${relativePath}`;
+
+      // Rewrite internal spec-dir references using seed spec dir name
+      const rewritten = rewriteSpecDirBuffer(buffer, file.path, [seedSpecDirName], specDirName);
+      await writeBuffer(cwd, localPath, rewritten.buffer, { overwrite: true });
+      logger.info(`  Updated: ${localPath}`);
     } catch (err) {
       logger.error(`  Failed to update ${file.path}:`, err && err.message ? err.message : err);
     }
@@ -163,8 +190,10 @@ async function updateGitHubWorkflows(cwd, tree, githubClient) {
  * @param {GitHubClient} githubClient - GitHub client instance
  * @param {string} wrapperDir - Directory containing wrapper templates
  * @param {string} extension - File extension to filter
+ * @param {string} specDirName - Local spec directory name (e.g., 'r3nd', 'rnd')
+ * @param {string} seedSpecDirName - Seed repo's spec directory name (e.g., 'r3nd', 'rnd')
  */
-async function updateComposedAgents(cwd, tree, githubClient, wrapperDir, extension, specDirName) {
+async function updateComposedAgents(cwd, tree, githubClient, wrapperDir, extension, specDirName, seedSpecDirName) {
   const platformName = wrapperDir === '.github/agents' ? 'GitHub Copilot' : 
                        wrapperDir === '.cursor/commands' ? 'Cursor' : 'VSCode';
   logger.info(`\n📝 Updating ${platformName} agent files...`);
@@ -191,14 +220,23 @@ async function updateComposedAgents(cwd, tree, githubClient, wrapperDir, extensi
   // Build file cache for template resolution
   const fileCache = new Map();
   
+  // Fetch all agent files from seed repo's configured spec directory
+  const seedAgentsPath = `${seedSpecDirName}/agents/`;
   const personaFiles = tree.filter(item => 
-    item.type === 'blob' && item.path.startsWith('rnd/agents/')
+    item.type === 'blob' && item.path.startsWith(seedAgentsPath)
   );
   
   for (const file of personaFiles) {
     try {
       const buffer = await githubClient.fetchRaw(file.path);
+      
+      // Store in cache with both seed repo path and local path for resolution flexibility
       fileCache.set(file.path, buffer);
+      
+      // Also map to local path so templates can reference either rnd/agents or specDirName/agents
+      const relativePath = file.path.substring(seedAgentsPath.length);
+      const localPath = `${specDirName}/agents/${relativePath}`;
+      fileCache.set(localPath, buffer);
     } catch (err) {
       logger.error(`  Failed to cache ${file.path}:`, err && err.message ? err.message : err);
     }
@@ -217,10 +255,20 @@ async function updateComposedAgents(cwd, tree, githubClient, wrapperDir, extensi
       
       // Resolve template placeholders
       const composedContent = await resolveTemplate(wrapperContent, fileReader);
-      const rewritten = rewriteSpecDirContent(composedContent, ['rnd'], specDirName);
+      const rewritten = rewriteSpecDirContent(composedContent, [seedSpecDirName], specDirName);
+      
+      // Replace spec directory references from seed repo to local spec directory
+      // This handles cases where the seed repo uses a different spec-dir-name (e.g., 'rnd')
+      // and the local repo uses a different one (e.g., 'r3nd')
+      let finalContent = rewritten.content;
+      if (seedSpecDirName !== specDirName) {
+        // Replace patterns like "rnd/agents/", "rnd/product_specs/", "rnd/tech_specs/", "rnd/build_plans/"
+        const specDirPattern = new RegExp(`\\b${seedSpecDirName}/`, 'g');
+        finalContent = finalContent.replace(specDirPattern, `${specDirName}/`);
+      }
       
       // Write composed file
-      await writeBuffer(cwd, file.path, Buffer.from(rewritten.content, 'utf-8'), { overwrite: true });
+      await writeBuffer(cwd, file.path, Buffer.from(finalContent, 'utf-8'), { overwrite: true });
       logger.info(`  Updated: ${file.path}`);
     } catch (err) {
       logger.error(`  Failed to update ${file.path}:`, err && err.message ? err.message : err);

--- a/cli/src/lib/updateService.spec.js
+++ b/cli/src/lib/updateService.spec.js
@@ -1,7 +1,8 @@
 // Mock inquirer to avoid ESM import issues
 jest.mock('./ui/prompts', () => ({
   askUpdateOptions: jest.fn().mockResolvedValue(['templates', 'agents', 'github', 'cursor', 'vscode']),
-  askSeedRepo: jest.fn().mockResolvedValue('leandronoijo/r3nd@develop')
+  askSeedRepo: jest.fn().mockResolvedValue('leandronoijo/r3nd@develop'),
+  askSpecDirName: jest.fn().mockResolvedValue('r3nd')
 }));
 
 // Mock config manager


### PR DESCRIPTION
Changes:
- Rename existing spec directory when `spec-dir-name` is updated in `r3nd.yaml`.
- Log an informational message on successful rename.
- Add unit tests for successful rename, conflict when target exists, missing-old-dir behavior, and log emission.

This updates `cli/src/lib/config/configManager.js` and adds tests in `cli/src/lib/config/configManager.spec.js`.