### PR TITLE
Refactor analyse to skill-driven AGENTS/CLAUDE generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ node src/index.js <command>
 | `init` | Initialize current directory with minimal r3nd seed files |
 | `scaffold` | Full interactive scaffolding with backend/frontend overlays (for new projects starting from zero — do not use on repos with existing application code) |
 | `update` | Update r3nd components from the seed repository |
-| `analyse` | Generate instruction files from existing codebase using AI |
+| `analyse` | Generate `AGENTS.md` / `CLAUDE.md` context files from existing codebase using AI |
 | `agents` | Run AI agents for specs, plans, and development |
 | `tools` | Show available and missing AI agent tools |
 | `config` | Manage r3nd.yaml configuration |
@@ -195,6 +195,9 @@ node src/index.js <command>
 | `create-test-cases` | Generate E2E test cases from a build plan |
 | `run-e2e-tests` | Execute E2E tests and generate result reports |
 | `create-retro-report` | Review PR discussions and create a retro report |
+| `analyze-repo-context` | Analyze a repo root and generate repo-level context files |
+| `analyze-app-context` | Analyze an app path and generate app-level context files |
+| `analyze-module-context` | Analyze a module path and generate module-level context files |
 
 ### Agent Options
 
@@ -239,8 +242,10 @@ r3nd agents implement-feature --file rnd/tech_specs/auth.md --agent codex
 # Analyse existing codebase
 r3nd analyse --agent codex --non-interactive
 
-# Analyse specific directory
-r3nd analyse --dir apps/backend --agent github
+# Analyze repo/app/module scopes directly via agent subcommands
+r3nd agents analyze-repo-context --input . --agent codex
+r3nd agents analyze-app-context --input apps/backend --agent codex
+r3nd agents analyze-module-context --input apps/backend/src/modules/auth --agent claude
 
 # Check which AI tools are installed
 r3nd tools

--- a/cli/README.md
+++ b/cli/README.md
@@ -60,21 +60,16 @@ Commands:
 
 - `scaffold`: Full project scaffolding (existing behaviour) — prompts for backend/frontend overlays and copies matching overlays and rnd build plans. Ensures the retro skill/template/workflow are present even when resuming from an existing setup.
 
-- `analyse`: Analyse the repository and generate `project.instructions.md` and per-app instruction files using an LLM agent.
+- `analyse`: Analyze repository and app scopes and generate `AGENTS.md` / `CLAUDE.md` files using an LLM agent.
   - Options:
-    - `-a, --agent <agent>`: Agent to use (`codex|claude|gemini|github|generate`). `github` runs the remote GitHub agent via `gh agent-task`. Default: `codex` (or first available agent).
+    - `-a, --agent <agent>`: Agent to use (`codex|claude|gemini|github`). `github` runs the remote GitHub agent via `gh agent-task`. Default: `codex` (or first available agent).
     - `-n, --non-interactive`: Run without interactive prompts.
-    - `-d, --dir <directory>`: Target a specific app/service directory instead of the whole project. Generates instructions for just that directory.
   - **Note**: Only agents installed on your system will be available as options.
   - Examples:
 
     ```bash
-    # Analyse entire project
+    # Analyze entire project (repo-level + selected app-level scopes)
     node src/index.js analyse --non-interactive --agent codex
-    
-    # Analyse a specific directory
-    node src/index.js analyse --dir src/backend --agent codex
-    r3nd analyse --dir cli/src --agent generate --non-interactive
     ```
 
 - `agents`: Run AI agents for generating specs, plans, and implementing features. See [Agents Command Documentation](docs/agents-command.md) for details.
@@ -87,6 +82,9 @@ Commands:
     - `create-test-cases`: Generate E2E test cases from a build plan
     - `run-e2e-tests`: Generate, run, and diagnose E2E tests from test cases
     - `create-retro-report`: Review PR discussions and create a retro report
+    - `analyze-repo-context`: Analyze repo root and generate repo-level `AGENTS.md` / `CLAUDE.md`
+    - `analyze-app-context`: Analyze app path and generate app-level `AGENTS.md` / `CLAUDE.md`
+    - `analyze-module-context`: Analyze module path and generate module-level `AGENTS.md` / `CLAUDE.md`
   - **Note**: Only agents installed on your system will be available as options.
   - **Spec Directory Option**: Use `--spec-dir <path>` to specify where spec files should be saved (e.g., `apps/my-app`, `services/auth`). Files will be saved in `<spec-dir>/<spec-dir-name>/` where `spec-dir-name` comes from your r3nd.yaml config (defaults to `r3nd`).
   - **Instruction Source**: These commands read task instructions from `<spec-dir>/<spec-dir-name>/skills/<task>/SKILL.md`.
@@ -113,6 +111,11 @@ Commands:
     r3nd agents create-product-spec --spec-dir apps/mobile --agent github    # → apps/mobile/r3nd/product_specs/
     r3nd agents create-product-spec --spec-dir apps/web --agent github       # → apps/web/r3nd/product_specs/
     r3nd agents create-tech-spec --spec-dir workspaces/shared --agent codex  # → workspaces/shared/r3nd/tech_specs/
+
+    # Context-analysis skills (path provided via --input)
+    r3nd agents analyze-repo-context --input . --agent codex
+    r3nd agents analyze-app-context --input apps/backend --agent codex
+    r3nd agents analyze-module-context --input apps/backend/src/modules/auth --agent claude
     ```
 
 - `tools`: Show which AI tools are available on your system.

--- a/cli/src/commands/agents.js
+++ b/cli/src/commands/agents.js
@@ -209,7 +209,11 @@ async function handleFreeTextAgent(agentConfig, opts, cwd, nonInteractive) {
   let userInput = opts.input;
   
   if (!userInput) {
-    logger.info('\nThis agent requires a feature description as input.');
+    if (nonInteractive) {
+      logger.error(`--input is required for "r3nd agents ${agentConfig.name}" in non-interactive mode.`);
+      process.exit(1);
+    }
+    logger.info('\nThis agent requires text input.');
     userInput = await askFeatureDescription(nonInteractive);
   }
 

--- a/cli/src/commands/agents.spec.js
+++ b/cli/src/commands/agents.spec.js
@@ -1,0 +1,21 @@
+jest.mock('inquirer', () => ({
+  createPromptModule: jest.fn(() => jest.fn().mockResolvedValue({}))
+}));
+
+const { Command } = require('commander');
+const { register } = require('./agents');
+
+describe('agents command registration', () => {
+  test('registers analysis subcommands from agent registry', () => {
+    const program = new Command();
+    register(program);
+
+    const agentsRoot = program.commands.find(cmd => cmd.name() === 'agents');
+    expect(agentsRoot).toBeDefined();
+
+    const names = agentsRoot.commands.map(cmd => cmd.name());
+    expect(names).toContain('analyze-repo-context');
+    expect(names).toContain('analyze-app-context');
+    expect(names).toContain('analyze-module-context');
+  });
+});

--- a/cli/src/commands/analyse.js
+++ b/cli/src/commands/analyse.js
@@ -4,17 +4,15 @@ const { askAnalyseAgent } = require('../lib/ui/prompts');
 function register(program) {
   program
     .command('analyse')
-    .description('Analyse the repository and generate project/app instruction files using LLM agents')
-    .option('-a, --agent <agent>', 'Agent to use (codex|claude|gemini|github|generate)', 'codex')
+    .description('Analyse repository/app scopes and generate AGENTS.md / CLAUDE.md files using LLM agents')
+    .option('-a, --agent <agent>', 'Agent to use (codex|claude|gemini|github)', 'codex')
     .option('-n, --non-interactive', 'Run without prompting', false)
-    .option('-d, --dir <directory>', 'Target a specific app/service directory instead of the whole project')
     .action(async (opts) => {
       try {
         const agent = opts.nonInteractive ? opts.agent : await askAnalyseAgent(opts.agent);
         await runAnalyse({ 
           agent, 
-          nonInteractive: !!opts.nonInteractive,
-          targetDir: opts.dir 
+          nonInteractive: !!opts.nonInteractive
         });
       } catch (err) {
         console.error('Analyse failed:', err && err.message ? err.message : err);

--- a/cli/src/commands/analyse.spec.js
+++ b/cli/src/commands/analyse.spec.js
@@ -1,0 +1,36 @@
+jest.mock('../lib/analyse', () => ({
+  runAnalyse: jest.fn().mockResolvedValue(undefined)
+}));
+
+jest.mock('../lib/ui/prompts', () => ({
+  askAnalyseAgent: jest.fn(async (agent) => agent || 'codex')
+}));
+
+const { Command } = require('commander');
+const { register } = require('./analyse');
+const { runAnalyse } = require('../lib/analyse');
+
+describe('analyse command registration', () => {
+  test('does not register --dir option', () => {
+    const program = new Command();
+    register(program);
+
+    const analyseCmd = program.commands.find(cmd => cmd.name() === 'analyse');
+    expect(analyseCmd).toBeDefined();
+
+    const optionFlags = analyseCmd.options.map(option => option.long);
+    expect(optionFlags).not.toContain('--dir');
+  });
+
+  test('passes only agent and nonInteractive to runAnalyse', async () => {
+    const program = new Command();
+    register(program);
+
+    await program.parseAsync(['node', 'test', 'analyse', '--non-interactive', '--agent', 'codex']);
+
+    expect(runAnalyse).toHaveBeenCalledWith({
+      agent: 'codex',
+      nonInteractive: true
+    });
+  });
+});

--- a/cli/src/lib/agents/agentRegistry.js
+++ b/cli/src/lib/agents/agentRegistry.js
@@ -132,6 +132,39 @@ const AGENT_REGISTRY = [
       `Using the task skill at ${agentFile} as instructions, analyze the following PR identifier or URL:\n\n${userInput}\n\nFollow the template at ${specDirPath}/templates/retro.md and ensure all sections are properly filled out. Analyze review comments, review threads, and issue comments to identify improvements to agents, templates, or instructions.\n\nIMPORTANT: Before analyzing the PR, read all agent summary logs from ${specDirPath}/agent_summaries/ to understand what happened during the development process. These logs contain summaries of agent interactions and will provide context about the workflow that led to this PR.\n\nSave the retro report in: ${specDirPath}/retros/`,
     interactiveSuffix: (doneFile, specDirPath) =>
       `\n\nIMPORTANT INSTRUCTIONS FOR INTERACTIVE MODE:\n1. First, read all files in ${specDirPath}/agent_summaries/ to understand the development process.\n2. Then review the PR discussion and comments.\n3. After completing the retro report, provide a summary of the key findings and recommendations.\n4. Ask if any areas need further analysis or if additional recommendations should be included.\n5. Then follow the shared summary workflow below.\n6. Do not create an agent summary log for the retro workflow.\n7. After the user confirms satisfaction, create the file named "${doneFile}" in the current directory.\n8. After creating the done file, delete all files in ${specDirPath}/agent_summaries/ to clean up for the next development cycle.${getSharedSummaryWorkflow(doneFile)}`
+  },
+  {
+    name: 'analyze-repo-context',
+    description: 'Analyze a repository root and generate AGENTS.md/CLAUDE.md context files',
+    filesDir: null,
+    agentFile: (specDirPath) => `${specDirPath}/skills/analyze-repo-context/SKILL.md`,
+    useFreeTextInput: true,
+    promptTemplate: (agentFile, userInput) =>
+      `Using the task skill at ${agentFile} as instructions, analyze this repository-level scope path:\n\n${userInput}\n\nIMPORTANT: Validate the path first. If it is missing or invalid for this level, explain why and refuse to proceed.`,
+    interactiveSuffix: (doneFile) =>
+      `\n\nIMPORTANT INSTRUCTIONS FOR INTERACTIVE MODE:\n1. After completing the repository analysis, summarize what was generated and where.\n2. Ask whether any app-level paths should be analyzed next.\n3. Then follow the shared summary workflow below.${getSharedSummaryWorkflow(doneFile)}`
+  },
+  {
+    name: 'analyze-app-context',
+    description: 'Analyze an app scope and generate AGENTS.md/CLAUDE.md context files',
+    filesDir: null,
+    agentFile: (specDirPath) => `${specDirPath}/skills/analyze-app-context/SKILL.md`,
+    useFreeTextInput: true,
+    promptTemplate: (agentFile, userInput) =>
+      `Using the task skill at ${agentFile} as instructions, analyze this app-level scope path:\n\n${userInput}\n\nIMPORTANT: Validate the path first. If it is missing or invalid for this level, explain why and refuse to proceed.`,
+    interactiveSuffix: (doneFile) =>
+      `\n\nIMPORTANT INSTRUCTIONS FOR INTERACTIVE MODE:\n1. After completing the app analysis, summarize what was generated and where.\n2. Ask whether any module-level paths should be analyzed next.\n3. Then follow the shared summary workflow below.${getSharedSummaryWorkflow(doneFile)}`
+  },
+  {
+    name: 'analyze-module-context',
+    description: 'Analyze a module scope and generate AGENTS.md/CLAUDE.md context files',
+    filesDir: null,
+    agentFile: (specDirPath) => `${specDirPath}/skills/analyze-module-context/SKILL.md`,
+    useFreeTextInput: true,
+    promptTemplate: (agentFile, userInput) =>
+      `Using the task skill at ${agentFile} as instructions, analyze this module-level scope path:\n\n${userInput}\n\nIMPORTANT: Validate the path first. If it is missing or invalid for this level, explain why and refuse to proceed.`,
+    interactiveSuffix: (doneFile) =>
+      `\n\nIMPORTANT INSTRUCTIONS FOR INTERACTIVE MODE:\n1. After completing the module analysis, summarize what was generated and where.\n2. Ask whether additional modules should be analyzed.\n3. Then follow the shared summary workflow below.${getSharedSummaryWorkflow(doneFile)}`
   }
 ];
 

--- a/cli/src/lib/agents/agentRegistry.spec.js
+++ b/cli/src/lib/agents/agentRegistry.spec.js
@@ -20,13 +20,16 @@ describe('agentRegistry', () => {
       });
     });
 
-    it('should include create-tech-spec, create-build-plan, implement-build-plan, and implement-feature agents', () => {
+    it('should include core planning/implementation and analysis agents', () => {
       const agents = getAgents();
       const names = agents.map(a => a.name);
       expect(names).toContain('create-tech-spec');
       expect(names).toContain('create-build-plan');
       expect(names).toContain('implement-build-plan');
       expect(names).toContain('implement-feature');
+      expect(names).toContain('analyze-repo-context');
+      expect(names).toContain('analyze-app-context');
+      expect(names).toContain('analyze-module-context');
     });
   });
 
@@ -175,6 +178,16 @@ describe('agentRegistry', () => {
       
       const prompt = resolved.promptTemplate(resolved.agentFile, 'test input', resolved.fullSpecDir);
       expect(prompt).toContain('r3nd/product_specs/');
+    });
+
+    it('should generate path-validation prompt for analyze-repo-context agent', () => {
+      const agent = getAgent('analyze-repo-context');
+      const resolved = resolveAgentConfig(agent, 'specs');
+      const prompt = resolved.promptTemplate(resolved.agentFile, '.', resolved.fullSpecDir);
+
+      expect(prompt).toContain('specs/skills/analyze-repo-context/SKILL.md');
+      expect(prompt).toContain('repository-level scope path');
+      expect(prompt).toContain('If it is missing or invalid');
     });
 
     it('should resolve implement-feature paths with custom spec directory base', () => {

--- a/cli/src/lib/analyse.flow.spec.js
+++ b/cli/src/lib/analyse.flow.spec.js
@@ -1,0 +1,110 @@
+// Mock inquirer transitively used by prompts module.
+jest.mock('inquirer', () => ({
+  createPromptModule: jest.fn(() => jest.fn().mockResolvedValue({}))
+}));
+
+jest.mock('./llm/agentRunner', () => ({
+  runPlansSequential: jest.fn(),
+  makeGitHubCommand: jest.fn((prompt) => `gh agent-task create "${prompt}"`)
+}));
+
+jest.mock('./ui/prompts', () => ({
+  confirmRunNow: jest.fn().mockResolvedValue(true),
+  askSelectApps: jest.fn((apps, nonInteractive) => (nonInteractive ? apps : apps.slice(0, 1)))
+}));
+
+jest.mock('./config/configManager', () => ({
+  ConfigManager: jest.fn().mockImplementation(() => ({
+    getSpecDirName: jest.fn().mockResolvedValue('r3nd')
+  }))
+}));
+
+jest.mock('./fs/treeSearch', () => ({
+  findFirstSpecDirectory: jest.fn().mockResolvedValue('r3nd')
+}));
+
+const fs = require('fs').promises;
+const os = require('os');
+const path = require('path');
+const { runPlansSequential } = require('./llm/agentRunner');
+const { runAnalyse } = require('./analyse');
+
+describe('runAnalyse flow orchestration', () => {
+  let tempDir;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'r3nd-analyse-flow-'));
+    await fs.mkdir(path.join(tempDir, 'r3nd', 'skills', 'analyze-repo-context'), { recursive: true });
+    await fs.mkdir(path.join(tempDir, 'r3nd', 'skills', 'analyze-app-context'), { recursive: true });
+    await fs.writeFile(path.join(tempDir, 'r3nd', 'skills', 'analyze-repo-context', 'SKILL.md'), '# repo skill', 'utf-8');
+    await fs.writeFile(path.join(tempDir, 'r3nd', 'skills', 'analyze-app-context', 'SKILL.md'), '# app skill', 'utf-8');
+  });
+
+  afterEach(async () => {
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test('runs level-1 then level-2 analysis for selected apps', async () => {
+    await fs.mkdir(path.join(tempDir, 'apps', 'api'), { recursive: true });
+
+    runPlansSequential.mockImplementation(async (_plans, { makePrompt }) => {
+      const prompt = await makePrompt('dummy');
+      if (prompt.includes('analyze this repository path')) {
+        await fs.writeFile(path.join(tempDir, 'AGENTS.md'), '```yaml\napps:\n  - name: api\n    path: apps/api\n    purpose: API\n    stack: node\n```', 'utf-8');
+        return;
+      }
+
+      const match = prompt.match(/analyze this application path:\n\n([^\n]+)/i);
+      if (match) {
+        const appPath = match[1].trim();
+        await fs.writeFile(path.join(tempDir, appPath, 'AGENTS.md'), '# App instructions', 'utf-8');
+      }
+    });
+
+    await runAnalyse({ agent: 'codex', nonInteractive: true, destRoot: tempDir });
+
+    expect(runPlansSequential).toHaveBeenCalledTimes(2);
+    await expect(fs.readFile(path.join(tempDir, 'AGENTS.md'), 'utf-8')).resolves.toContain('apps:');
+    await expect(fs.readFile(path.join(tempDir, 'apps', 'api', 'AGENTS.md'), 'utf-8')).resolves.toContain('App instructions');
+  });
+
+  test('stops after level-1 when no apps are found', async () => {
+    runPlansSequential.mockImplementation(async (_plans, { makePrompt }) => {
+      const prompt = await makePrompt('dummy');
+      if (prompt.includes('analyze this repository path')) {
+        await fs.writeFile(path.join(tempDir, 'AGENTS.md'), '# No apps listed', 'utf-8');
+      }
+    });
+
+    await runAnalyse({ agent: 'codex', nonInteractive: true, destRoot: tempDir });
+    expect(runPlansSequential).toHaveBeenCalledTimes(1);
+  });
+
+  test('non-interactive mode analyzes all parsed apps by default', async () => {
+    await fs.mkdir(path.join(tempDir, 'apps', 'api'), { recursive: true });
+    await fs.mkdir(path.join(tempDir, 'apps', 'web'), { recursive: true });
+
+    runPlansSequential.mockImplementation(async (_plans, { makePrompt }) => {
+      const prompt = await makePrompt('dummy');
+      if (prompt.includes('analyze this repository path')) {
+        await fs.writeFile(path.join(tempDir, 'AGENTS.md'), '```yaml\napps:\n  - name: api\n    path: apps/api\n    purpose: API\n    stack: node\n  - name: web\n    path: apps/web\n    purpose: Web\n    stack: react\n```', 'utf-8');
+        return;
+      }
+
+      const match = prompt.match(/analyze this application path:\n\n([^\n]+)/i);
+      if (match) {
+        const appPath = match[1].trim();
+        await fs.writeFile(path.join(tempDir, appPath, 'AGENTS.md'), `# ${appPath}`, 'utf-8');
+      }
+    });
+
+    await runAnalyse({ agent: 'codex', nonInteractive: true, destRoot: tempDir });
+
+    expect(runPlansSequential).toHaveBeenCalledTimes(3);
+    await expect(fs.readFile(path.join(tempDir, 'apps', 'api', 'AGENTS.md'), 'utf-8')).resolves.toContain('apps/api');
+    await expect(fs.readFile(path.join(tempDir, 'apps', 'web', 'AGENTS.md'), 'utf-8')).resolves.toContain('apps/web');
+  });
+});

--- a/cli/src/lib/analyse.js
+++ b/cli/src/lib/analyse.js
@@ -1,29 +1,28 @@
 const path = require('path');
 const fs = require('fs').promises;
-const { runCodexCommand, runPlansSequential, makeGitHubCommand } = require('./llm/agentRunner');
-const { writeBuffer, ensureDir } = require('./fs/fileWriter');
-const { buildOverviewPrompt, buildAppPrompt, buildTargetedAppPrompt } = require('./analyse/prompts');
+const { runPlansSequential, makeGitHubCommand } = require('./llm/agentRunner');
 const { confirmRunNow, askSelectApps } = require('./ui/prompts');
 const { ConfigManager } = require('./config/configManager');
 const { findFirstSpecDirectory } = require('./fs/treeSearch');
-const { copyInstructionsToRnd } = require('./fs/seedCopier');
 const YAML = require('yaml');
 
-// Regex patterns for parsing fenced code blocks
 const YAML_FENCED_BLOCK_REGEX = /```(?:yaml|yml)\s*([\s\S]*?)```/i;
 const JSON_FENCED_BLOCK_REGEX = /```json\s*([\s\S]*?)```/i;
 
-function normalizeAppEntry(a) {
-  return { 
-    name: a.name || a.app || 'unknown', 
-    path: a.path || '.', 
-    purpose: a.purpose || '', 
-    stack: a.stack || '' 
+const AGENTS_MD = 'AGENTS.md';
+const CLAUDE_MD = 'CLAUDE.md';
+
+function normalizeAppEntry(appEntry = {}) {
+  return {
+    name: appEntry.name || appEntry.app || 'unknown',
+    path: appEntry.path || appEntry.applyTo || '.',
+    applyTo: appEntry.applyTo || appEntry.path || '.',
+    purpose: appEntry.purpose || '',
+    stack: appEntry.stack || ''
   };
 }
 
 async function parseAppsFromInstructions(content) {
-  // Try YAML fenced block first (preferred format)
   const yamlMatch = content.match(YAML_FENCED_BLOCK_REGEX);
   if (yamlMatch) {
     try {
@@ -31,93 +30,179 @@ async function parseAppsFromInstructions(content) {
       if (parsed && Array.isArray(parsed.apps)) {
         return parsed.apps.map(normalizeAppEntry);
       }
-    } catch (e) {
-      console.warn('Failed to parse YAML fenced block for apps:', e && e.message ? e.message : e);
-      // fall through to JSON parser
+    } catch (err) {
+      console.warn('Failed to parse YAML fenced block for apps:', err && err.message ? err.message : err);
     }
   }
 
-  // Fallback to JSON fenced block for backwards compatibility
   const jsonMatch = content.match(JSON_FENCED_BLOCK_REGEX);
   if (jsonMatch) {
     try {
-      const raw = jsonMatch[1].trim();
-      const parsed = JSON.parse(raw);
-      // If the JSON block is directly an array of apps
-      if (Array.isArray(parsed)) return parsed.map(normalizeAppEntry);
-      // If it's an object with `apps` property
-      if (Array.isArray(parsed.apps)) return parsed.apps.map(normalizeAppEntry);
-    } catch (e) {
-      console.warn('Failed to parse JSON fenced block for apps:', e && e.message ? e.message : e);
-      // fall through to empty
+      const parsed = JSON.parse(jsonMatch[1].trim());
+      if (Array.isArray(parsed)) {
+        return parsed.map(normalizeAppEntry);
+      }
+      if (parsed && Array.isArray(parsed.apps)) {
+        return parsed.apps.map(normalizeAppEntry);
+      }
+    } catch (err) {
+      console.warn('Failed to parse JSON fenced block for apps:', err && err.message ? err.message : err);
     }
   }
 
   return [];
 }
 
-async function parseAppNameFromMetadata(content) {
-  // Try YAML fenced block first
-  const yamlMatch = content.match(YAML_FENCED_BLOCK_REGEX);
-  if (yamlMatch) {
-    try {
-      const parsed = YAML.parse(yamlMatch[1]);
-      if (parsed && parsed.name) return parsed.name;
-    } catch (e) {
-      // fall through to JSON
-    }
-  }
-
-  // Try JSON fenced block
-  const jsonMatch = content.match(JSON_FENCED_BLOCK_REGEX);
-  if (jsonMatch) {
-    try {
-      const raw = jsonMatch[1].trim();
-      const parsed = JSON.parse(raw);
-      if (parsed && parsed.name) return parsed.name;
-    } catch (e) {
-      // fall through
-    }
-  }
-
-  return null;
+function escapeSingleQuotes(value) {
+  return value.replace(/'/g, "'\\''");
 }
 
-async function runAnalyse({ agent = 'codex', nonInteractive = false, destRoot = process.cwd(), targetDir = null } = {}) {
-  // Get configured spec directory name
+function escapeDoubleQuotes(value) {
+  return value.replace(/"/g, '\\"');
+}
+
+async function exists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function detectRequiredAnalysisFiles(repoRoot) {
+  const hasClaudeVendor = await exists(path.join(repoRoot, '.claude'));
+  const hasAgentsVendor =
+    await exists(path.join(repoRoot, '.codex')) ||
+    await exists(path.join(repoRoot, '.cursor')) ||
+    await exists(path.join(repoRoot, '.github'));
+
+  const requiredFiles = [];
+  if (hasAgentsVendor || !hasClaudeVendor) {
+    requiredFiles.push(AGENTS_MD);
+  }
+  if (hasClaudeVendor) {
+    requiredFiles.push(CLAUDE_MD);
+  }
+
+  return {
+    hasClaudeVendor,
+    hasAgentsVendor,
+    requiredFiles
+  };
+}
+
+async function ensureRequiredScopeFiles(scopePath, requiredFiles) {
+  const agentsPath = path.join(scopePath, AGENTS_MD);
+  const claudePath = path.join(scopePath, CLAUDE_MD);
+  const agentsExists = await exists(agentsPath);
+  const claudeExists = await exists(claudePath);
+
+  if (requiredFiles.includes(AGENTS_MD) && !agentsExists && claudeExists) {
+    const source = await fs.readFile(claudePath);
+    await fs.writeFile(agentsPath, source);
+  }
+
+  if (requiredFiles.includes(CLAUDE_MD) && !claudeExists && agentsExists) {
+    const source = await fs.readFile(agentsPath);
+    await fs.writeFile(claudePath, source);
+  }
+
+  const missing = [];
+  for (const requiredFile of requiredFiles) {
+    const requiredPath = path.join(scopePath, requiredFile);
+    if (!(await exists(requiredPath))) {
+      missing.push(requiredFile);
+    }
+  }
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required analysis files in ${scopePath}: ${missing.join(', ')}. ` +
+      'Ensure the analysis skill generated the expected files.'
+    );
+  }
+}
+
+async function readAnalysisSource(scopePath, requiredFiles) {
+  const orderedCandidates = [AGENTS_MD, CLAUDE_MD, ...requiredFiles.filter(f => f !== AGENTS_MD && f !== CLAUDE_MD)];
+
+  for (const candidate of orderedCandidates) {
+    const candidatePath = path.join(scopePath, candidate);
+    if (await exists(candidatePath)) {
+      return fs.readFile(candidatePath, 'utf8');
+    }
+  }
+
+  throw new Error(`No analysis output file found in ${scopePath}`);
+}
+
+function makeCommandForAgent(agent, promptText) {
+  if (agent === 'claude') {
+    return `claude --dangerously-skip-permissions \"${escapeDoubleQuotes(promptText)}\"`;
+  }
+  if (agent === 'gemini') {
+    return `gemini --yolo -i \"${escapeDoubleQuotes(promptText)}\"`;
+  }
+  if (agent === 'github') {
+    return makeGitHubCommand(promptText);
+  }
+  return `codex --yolo '${escapeSingleQuotes(promptText)}'`;
+}
+
+function buildSkillExecutionPrompt({ skillPath, scopePath, scopeKind }) {
+  return [
+    `Using the task skill at ${skillPath} as instructions, analyze this ${scopeKind} path:`,
+    '',
+    scopePath,
+    '',
+    'Follow the skill instructions exactly. If the path is invalid or missing, explain the issue and refuse to continue.',
+    'When complete, ensure output files are saved at that scope root.'
+  ].join('\n');
+}
+
+async function runScopeAnalysis({
+  agent,
+  destRoot,
+  specDir,
+  skillName,
+  scopePath,
+  scopeKind
+}) {
+  const absoluteSkillPath = path.join(destRoot, specDir, 'skills', skillName, 'SKILL.md');
+  if (!(await exists(absoluteSkillPath))) {
+    throw new Error(`Required skill file not found: ${absoluteSkillPath}`);
+  }
+
+  const scopeRelative = path.isAbsolute(scopePath) ? path.relative(destRoot, scopePath) : scopePath;
+  const normalizedScope = scopeRelative && scopeRelative !== '' ? scopeRelative : '.';
+  const prompt = buildSkillExecutionPrompt({
+    skillPath: path.relative(destRoot, absoluteSkillPath),
+    scopePath: normalizedScope,
+    scopeKind
+  });
+
+  const pseudoPlanPath = path.join(specDir, 'build_plans', `${skillName}-${normalizedScope.replace(/[\\/]/g, '-') || 'root'}.md`);
+  const timeoutMs = parseInt(process.env.R3ND_AGENT_TIMEOUT || '3600000', 10);
+
+  await runPlansSequential([pseudoPlanPath], {
+    cwd: destRoot,
+    makePrompt: async () => prompt,
+    makeCommand: (builtPrompt) => makeCommandForAgent(agent, builtPrompt),
+    timeoutMs,
+    agentType: agent
+  });
+}
+
+async function runAnalyse({ agent = 'codex', nonInteractive = false, destRoot = process.cwd() } = {}) {
   const configManager = new ConfigManager(destRoot);
   const specDirName = await configManager.getSpecDirName();
-  
-  // Find spec directory
   const specDir = await findFirstSpecDirectory(destRoot, specDirName);
+
   if (!specDir) {
     throw new Error(`No ${specDirName} directory found in repository`);
   }
 
-  // Save instructions in spec directory instead of .github
-  const instructionsDir = path.join(destRoot, specDirName, 'instructions');
-  await ensureDir(instructionsDir);
-
-  // If targetDir is specified, run targeted app analysis
-  if (targetDir) {
-    return runTargetedAnalyse({ agent, nonInteractive, destRoot, targetDir, instructionsDir, specDir });
-  }
-
-  // Original full-project analysis flow
-  // Phase 1: build overview prompt
-  const overviewPrompt = buildOverviewPrompt(destRoot);
-
-  // If agent is 'generate', write the prompt to a file and exit
-  const projectInstructionsPath = path.join(instructionsDir, 'project.instructions.md');
-
-  if (agent === 'generate') {
-    const content = `<!-- GENERATED PROMPT -->\n\n${overviewPrompt}\n`;
-    await writeBuffer(destRoot, path.relative(destRoot, projectInstructionsPath), Buffer.from(content));
-    console.log(`Generated prompt written to ${projectInstructionsPath}`);
-    return;
-  }
-
-  // For codex/gemini/github: run the agent and require a .done file for each step
   if (!nonInteractive) {
     const proceed = await confirmRunNow(nonInteractive);
     if (!proceed) {
@@ -126,184 +211,59 @@ async function runAnalyse({ agent = 'codex', nonInteractive = false, destRoot = 
     }
   }
 
+  const vendorRequirements = await detectRequiredAnalysisFiles(destRoot);
+
   try {
-    // Phase 1: require the agent to write project.instructions.md and create a .done file
-    const projectPlanPath = path.join(specDir, 'build_plans', 'project-overview.md');
-    function makeOverviewPlanPrompt(planPath) {
-      const planName = path.basename(planPath, '.md');
-      if (agent === 'github') {
-        return `${overviewPrompt}\n\nIMPORTANT: Save the project-level instructions to ${path.relative(destRoot, projectInstructionsPath)}.`;
-      }
-      const doneFile = `${planName}.done`;
-      return `${overviewPrompt}\n\nIMPORTANT: Save the project-level instructions to ${path.relative(destRoot, projectInstructionsPath)}. When you have completely finished creating this file, create a file named ${doneFile} in the current directory to signal completion.`;
-    }
+    await runScopeAnalysis({
+      agent,
+      destRoot,
+      specDir,
+      skillName: 'analyze-repo-context',
+      scopePath: '.',
+      scopeKind: 'repository'
+    });
 
-    function makeCmdForPrompt(promptText) {
-      if (agent === 'claude') return `claude --dangerously-skip-permissions "${promptText.replace(/"/g, '\\"')}"`;
-      if (agent === 'gemini') return `gemini --yolo -i "${promptText.replace(/"/g, '\\"')}"`;
-      if (agent === 'github') return makeGitHubCommand(promptText);
-      return `codex --yolo '${promptText.replace(/'/g, "'\\''")}'`;
-    }
+    await ensureRequiredScopeFiles(destRoot, vendorRequirements.requiredFiles);
 
-    const timeoutMs = parseInt(process.env.R3ND_AGENT_TIMEOUT || '3600000', 10);
-    await runPlansSequential([projectPlanPath], { cwd: destRoot, makePrompt: async (p) => makeOverviewPlanPrompt(p), makeCommand: (prompt) => makeCmdForPrompt(prompt), timeoutMs, agentType: agent });
+    const repoContent = await readAnalysisSource(destRoot, vendorRequirements.requiredFiles);
+    const apps = await parseAppsFromInstructions(repoContent);
 
-    // After agent signals completion, read project.instructions.md (or write placeholder)
-    let fileContent = '';
-    try {
-      fileContent = await fs.readFile(projectInstructionsPath, 'utf8');
-    } catch (e) {
-      console.warn('Agent completed but did not produce project.instructions.md. Writing prompt as placeholder.');
-      await writeBuffer(destRoot, path.relative(destRoot, projectInstructionsPath), Buffer.from(overviewPrompt), { overwrite: true });
-      fileContent = overviewPrompt;
-    }
-
-    // Parse apps list
-    const apps = await parseAppsFromInstructions(fileContent);
     if (!apps || apps.length === 0) {
-      console.log('No apps detected in project.instructions.md. Nothing to generate.');
+      console.log('No apps detected in repository analysis output. Nothing else to analyze.');
       return;
     }
 
-    // Let user select which apps to analyze
     const selectedApps = await askSelectApps(apps, nonInteractive);
     if (!selectedApps || selectedApps.length === 0) {
       console.log('No apps selected for analysis.');
       return;
     }
 
-    console.log(`Selected ${selectedApps.length} app(s) for analysis: ${selectedApps.map(a => a.name).join(', ')}`);
+    console.log(`Selected ${selectedApps.length} app(s) for analysis: ${selectedApps.map(app => app.name).join(', ')}`);
 
-    // Phase 2: create per-app plans and require .done files for each
-    const appPlans = selectedApps.map(a => path.join(specDir, 'build_plans', `${a.name}.md`));
-
-    await runPlansSequential(appPlans, {
-      cwd: destRoot,
-      makePrompt: async (planPath) => {
-        const idx = appPlans.indexOf(planPath);
-        const app = selectedApps[idx];
-        const planName = path.basename(planPath, '.md');
-        const prompt = buildAppPrompt(app);
-        if (agent === 'github') {
-          return `${prompt}\n\nIMPORTANT: Save the instructions to ${path.relative(destRoot, path.join(instructionsDir, `${app.name}.instructions.md`))}.`;
-        }
-        const doneFile = `${planName}.done`;
-        return `${prompt}\n\nIMPORTANT: Save the instructions to ${path.relative(destRoot, path.join(instructionsDir, `${app.name}.instructions.md`))}. When you have completely finished creating this file, create a file named ${doneFile} in the current directory to signal completion.`;
-      },
-      makeCommand: (prompt) => makeCmdForPrompt(prompt),
-      timeoutMs,
-      agentType: agent
-    });
-
-    // Ensure any missing per-app files get placeholder content
     for (const app of selectedApps) {
-      const targetPath = path.join(instructionsDir, `${app.name}.instructions.md`);
-      try {
-        await fs.access(targetPath);
-        console.log(`Agent produced ${targetPath}`);
-      } catch (_) {
-        const appPrompt = buildAppPrompt(app);
-        await writeBuffer(destRoot, path.relative(destRoot, targetPath), Buffer.from(appPrompt), { overwrite: true });
-        console.log(`Wrote placeholder instructions to ${targetPath}`);
-      }
+      const appScopePath = app.path || app.applyTo || '.';
+      await runScopeAnalysis({
+        agent,
+        destRoot,
+        specDir,
+        skillName: 'analyze-app-context',
+        scopePath: appScopePath,
+        scopeKind: 'application'
+      });
+
+      const absoluteScopePath = path.resolve(destRoot, appScopePath);
+      await ensureRequiredScopeFiles(absoluteScopePath, vendorRequirements.requiredFiles);
     }
   } catch (err) {
-    console.error('Agent run failed:', err && err.message ? err.message : err);
+    console.error('Analyse failed:', err && err.message ? err.message : err);
     throw err;
   }
-
-  // Mirror generated instructions to the standard root location.
-  await copyInstructionsToRnd(destRoot, specDirName, { nonInteractive: true });
 }
 
-async function runTargetedAnalyse({ agent, nonInteractive, destRoot, targetDir, instructionsDir, specDir }) {
-  // Normalize targetDir to be relative to destRoot
-  const normalizedDir = path.isAbsolute(targetDir) 
-    ? path.relative(destRoot, targetDir) 
-    : targetDir;
-
-  console.log(`Analysing specific directory: ${normalizedDir}`);
-
-  const targetedPrompt = buildTargetedAppPrompt(normalizedDir);
-
-  if (agent === 'generate') {
-    // Generate a placeholder filename based on the directory
-    const dirName = path.basename(normalizedDir) || 'app';
-    const outputPath = path.join(instructionsDir, `${dirName}.instructions.md`);
-    const content = `<!-- GENERATED PROMPT -->\n\n${targetedPrompt}\n`;
-    await writeBuffer(destRoot, path.relative(destRoot, outputPath), Buffer.from(content));
-    console.log(`Generated prompt written to ${outputPath}`);
-    return;
-  }
-
-  if (!nonInteractive) {
-    const proceed = await confirmRunNow(nonInteractive);
-    if (!proceed) {
-      console.log('Aborted by user');
-      return;
-    }
-  }
-
-  try {
-    const dirName = path.basename(normalizedDir) || 'app';
-    const appPlanPath = path.join(specDir, 'build_plans', `${dirName}.md`);
-
-    function makeTargetedPlanPrompt(planPath) {
-      const planName = path.basename(planPath, '.md');
-      const outputPath = path.join(instructionsDir, `${dirName}.instructions.md`);
-      if (agent === 'github') {
-        return `${targetedPrompt}\n\nIMPORTANT: Save the instructions to ${path.relative(destRoot, outputPath)}.`;
-      }
-      const doneFile = `${planName}.done`;
-      return `${targetedPrompt}\n\nIMPORTANT: Save the instructions to ${path.relative(destRoot, outputPath)}. When you have completely finished creating this file, create a file named ${doneFile} in the current directory to signal completion.`;
-    }
-
-    function makeCmdForPrompt(promptText) {
-      if (agent === 'claude') return `claude --dangerously-skip-permissions "${promptText.replace(/"/g, '\\"')}"`;
-      if (agent === 'gemini') return `gemini --yolo -i "${promptText.replace(/"/g, '\\"')}"`;
-      if (agent === 'github') return makeGitHubCommand(promptText);
-      return `codex --yolo '${promptText.replace(/'/g, "'\\''")}'`;
-    }
-
-    const timeoutMs = parseInt(process.env.R3ND_AGENT_TIMEOUT || '3600000', 10);
-    await runPlansSequential([appPlanPath], { 
-      cwd: destRoot, 
-      makePrompt: async (p) => makeTargetedPlanPrompt(p), 
-      makeCommand: (prompt) => makeCmdForPrompt(prompt), 
-      timeoutMs, 
-      agentType: agent 
-    });
-
-    // Try to read the generated file to extract the app name
-    const outputPath = path.join(instructionsDir, `${dirName}.instructions.md`);
-    let fileContent = '';
-    try {
-      fileContent = await fs.readFile(outputPath, 'utf8');
-      
-      // Try to parse the app name from the metadata
-      const parsedName = await parseAppNameFromMetadata(fileContent);
-      if (parsedName && parsedName !== dirName) {
-        // Rename the file to match the parsed app name
-        const newOutputPath = path.join(instructionsDir, `${parsedName}.instructions.md`);
-        await fs.rename(outputPath, newOutputPath);
-        console.log(`Agent produced ${newOutputPath}`);
-      } else {
-        console.log(`Agent produced ${outputPath}`);
-      }
-    } catch (e) {
-      console.warn('Agent completed but did not produce the instruction file. Writing prompt as placeholder.');
-      await writeBuffer(destRoot, path.relative(destRoot, outputPath), Buffer.from(targetedPrompt), { overwrite: true });
-      console.log(`Wrote placeholder instructions to ${outputPath}`);
-    }
-  } catch (err) {
-    console.error('Agent run failed:', err && err.message ? err.message : err);
-    throw err;
-  }
-
-  // Mirror generated instructions to the standard root location.
-  const configManager = new ConfigManager(destRoot);
-  const specDirName = await configManager.getSpecDirName();
-  await copyInstructionsToRnd(destRoot, specDirName, { nonInteractive: true });
-}
-
-module.exports = { runAnalyse, parseAppsFromInstructions, parseAppNameFromMetadata };
+module.exports = {
+  runAnalyse,
+  parseAppsFromInstructions,
+  detectRequiredAnalysisFiles,
+  ensureRequiredScopeFiles
+};

--- a/cli/src/lib/analyse.spec.js
+++ b/cli/src/lib/analyse.spec.js
@@ -1,29 +1,28 @@
-// Mock inquirer before any imports
+// Mock inquirer before imports that rely on prompt module
 jest.mock('inquirer', () => ({
   createPromptModule: jest.fn(() => jest.fn().mockResolvedValue({}))
 }));
 
-const { buildOverviewPrompt, buildAppPrompt, buildTargetedAppPrompt } = require('./analyse/prompts');
-const { parseAppsFromInstructions, parseAppNameFromMetadata } = require('./analyse');
+const fs = require('fs').promises;
+const os = require('os');
+const path = require('path');
+const {
+  parseAppsFromInstructions,
+  detectRequiredAnalysisFiles,
+  ensureRequiredScopeFiles
+} = require('./analyse');
 
-describe('analyse prompts and parsing', () => {
-  test('overview prompt contains YAML block instruction', () => {
-    const p = buildOverviewPrompt();
-    expect(p).toMatch(/YAML/i);
-    expect(p).toMatch(/apps:/i);
+describe('analyse parsing and output verification', () => {
+  let tempDir;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'r3nd-analyse-'));
   });
 
-  test('app prompt mentions applyTo and sections', () => {
-    const p = buildAppPrompt({ name: 'foo', path: 'src/foo' });
-    expect(p).toMatch(/applyTo/i);
-    expect(p).toMatch(/Tech stack/i);
-  });
-
-  test('targeted app prompt includes target directory', () => {
-    const p = buildTargetedAppPrompt('src/backend');
-    expect(p).toContain('src/backend');
-    expect(p).toMatch(/Tech stack/i);
-    expect(p).toMatch(/applyTo/i);
+  afterEach(async () => {
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   test('parseAppsFromInstructions parses YAML block', async () => {
@@ -31,6 +30,14 @@ describe('analyse prompts and parsing', () => {
     const apps = await parseAppsFromInstructions(md);
     expect(Array.isArray(apps)).toBe(true);
     expect(apps[0].name).toBe('api');
+    expect(apps[0].path).toBe('src/backend');
+  });
+
+  test('parseAppsFromInstructions parses applyTo as path', async () => {
+    const md = '```yaml\napps:\n  - name: web\n    applyTo: apps/web\n    purpose: web\n    stack: react\n```';
+    const apps = await parseAppsFromInstructions(md);
+    expect(apps[0].path).toBe('apps/web');
+    expect(apps[0].applyTo).toBe('apps/web');
   });
 
   test('parseAppsFromInstructions parses JSON block for backwards compatibility', async () => {
@@ -40,21 +47,56 @@ describe('analyse prompts and parsing', () => {
     expect(apps[0].name).toBe('api');
   });
 
-  test('parseAppNameFromMetadata extracts name from YAML', async () => {
-    const md = 'Some intro\n```yaml\nname: my-app\napplyTo: src/app\n```\nRest of content';
-    const name = await parseAppNameFromMetadata(md);
-    expect(name).toBe('my-app');
+  test('detectRequiredAnalysisFiles requires CLAUDE only when only .claude exists', async () => {
+    await fs.mkdir(path.join(tempDir, '.claude'));
+    const result = await detectRequiredAnalysisFiles(tempDir);
+    expect(result.requiredFiles).toEqual(['CLAUDE.md']);
   });
 
-  test('parseAppNameFromMetadata extracts name from JSON', async () => {
-    const md = 'Some intro\n```json\n{"name":"api-service","applyTo":"src/backend"}\n```\nRest of content';
-    const name = await parseAppNameFromMetadata(md);
-    expect(name).toBe('api-service');
+  test('detectRequiredAnalysisFiles requires AGENTS for codex/cursor/github vendors', async () => {
+    await fs.mkdir(path.join(tempDir, '.codex'));
+    const result = await detectRequiredAnalysisFiles(tempDir);
+    expect(result.requiredFiles).toEqual(['AGENTS.md']);
   });
 
-  test('parseAppNameFromMetadata returns null if no metadata', async () => {
-    const md = 'Just some plain markdown without metadata blocks';
-    const name = await parseAppNameFromMetadata(md);
-    expect(name).toBeNull();
+  test('detectRequiredAnalysisFiles requires both files when claude and agents vendors coexist', async () => {
+    await fs.mkdir(path.join(tempDir, '.claude'));
+    await fs.mkdir(path.join(tempDir, '.github'), { recursive: true });
+    const result = await detectRequiredAnalysisFiles(tempDir);
+    expect(result.requiredFiles).toEqual(['AGENTS.md', 'CLAUDE.md']);
+  });
+
+  test('detectRequiredAnalysisFiles defaults to AGENTS when no vendors exist', async () => {
+    const result = await detectRequiredAnalysisFiles(tempDir);
+    expect(result.requiredFiles).toEqual(['AGENTS.md']);
+  });
+
+  test('ensureRequiredScopeFiles copies counterpart when AGENTS is required and missing', async () => {
+    const scope = path.join(tempDir, 'apps', 'backend');
+    await fs.mkdir(scope, { recursive: true });
+    await fs.writeFile(path.join(scope, 'CLAUDE.md'), 'same content', 'utf-8');
+
+    await ensureRequiredScopeFiles(scope, ['AGENTS.md']);
+
+    await expect(fs.readFile(path.join(scope, 'AGENTS.md'), 'utf-8')).resolves.toBe('same content');
+  });
+
+  test('ensureRequiredScopeFiles copies counterpart when CLAUDE is required and missing', async () => {
+    const scope = path.join(tempDir, 'apps', 'frontend');
+    await fs.mkdir(scope, { recursive: true });
+    await fs.writeFile(path.join(scope, 'AGENTS.md'), 'shared text', 'utf-8');
+
+    await ensureRequiredScopeFiles(scope, ['CLAUDE.md']);
+
+    await expect(fs.readFile(path.join(scope, 'CLAUDE.md'), 'utf-8')).resolves.toBe('shared text');
+  });
+
+  test('ensureRequiredScopeFiles throws when required files are still missing', async () => {
+    const scope = path.join(tempDir, 'apps', 'worker');
+    await fs.mkdir(scope, { recursive: true });
+
+    await expect(ensureRequiredScopeFiles(scope, ['AGENTS.md', 'CLAUDE.md']))
+      .rejects
+      .toThrow(/Missing required analysis files/);
   });
 });

--- a/cli/src/lib/fs/seedCopier.spec.js
+++ b/cli/src/lib/fs/seedCopier.spec.js
@@ -143,4 +143,60 @@ Use rnd/templates/tech_spec.md as the canonical template.
     expect(generated).toContain('specs/templates/tech_spec.md');
     expect(githubClient.fetchRaw).toHaveBeenCalledWith('rnd/skills/create-tech-spec/SKILL.md');
   });
+
+  it('generates vendor outputs for new analysis skills', async () => {
+    const tree = [
+      { type: 'blob', path: 'rnd/skills/analyze-repo-context/SKILL.md' },
+      { type: 'blob', path: 'rnd/vendor/skills/codex.md' },
+      { type: 'blob', path: 'rnd/agents/architect.md' },
+      { type: 'blob', path: 'rnd/agents/summary.md' },
+    ];
+
+    const fileMap = new Map([
+      ['rnd/skills/analyze-repo-context/SKILL.md', Buffer.from(`---
+name: analyze-repo-context
+description: Analyze repository context
+---
+
+# analyze-repo-context
+
+{{rnd/agents/architect.md}}
+
+{{rnd/agents/summary.md}}
+`)],
+      ['rnd/vendor/skills/codex.md', Buffer.from('## Codex-Specific Instructions')],
+      ['rnd/agents/architect.md', Buffer.from('# Architect Agent')],
+      ['rnd/agents/summary.md', Buffer.from('# Summary Workflow')],
+    ]);
+
+    const githubClient = {
+      fetchRaw: jest.fn(async (filePath) => {
+        if (!fileMap.has(filePath)) {
+          throw new Error(`Unexpected fetch: ${filePath}`);
+        }
+        return fileMap.get(filePath);
+      })
+    };
+
+    await syncPlatformAsset(
+      tempDir,
+      tree,
+      githubClient,
+      {
+        key: 'codex',
+        label: 'Codex Skills',
+        assetType: 'generated-skill',
+        vendor: 'codex',
+        outputPath: '.codex/skills',
+      },
+      'specs',
+      'rnd',
+      { nonInteractive: true, overwriteExisting: true }
+    );
+
+    const generated = await fs.readFile(path.join(tempDir, '.codex', 'skills', 'analyze-repo-context', 'SKILL.md'), 'utf-8');
+    expect(generated).toContain('# analyze-repo-context');
+    expect(generated).toContain('# Architect Agent');
+    expect(generated).toContain('## Codex-Specific Instructions');
+  });
 });

--- a/cli/src/lib/ui/prompts.js
+++ b/cli/src/lib/ui/prompts.js
@@ -164,14 +164,12 @@ async function askAnalyseAgent(defaultAgent = 'codex', nonInteractive = false) {
       gemini: 'Gemini CLI',
       github: 'GitHub agent via gh CLI',
     },
-    extraChoices: [
-      { name: 'Generate prompts only (no agent)', value: 'generate' },
-    ],
+    extraChoices: [],
   });
   
-  // If the default agent is not available, use the first available or 'generate'
+  // If the default agent is not available, use the first available installed agent.
   let effectiveDefault = defaultAgent;
-  if (defaultAgent !== 'generate' && !availableTools[defaultAgent]) {
+  if (!availableTools[defaultAgent]) {
     effectiveDefault = availableTools.codex
       ? 'codex'
       : availableTools.claude
@@ -180,7 +178,7 @@ async function askAnalyseAgent(defaultAgent = 'codex', nonInteractive = false) {
           ? 'gemini'
           : availableTools.github
             ? 'github'
-            : 'generate';
+            : defaultAgent;
   }
   
   const res = await prompt([{ 

--- a/rnd/skills/analyze-app-context/SKILL.md
+++ b/rnd/skills/analyze-app-context/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: analyze-app-context
+description: Analyze an app root and generate detailed app-level AGENTS.md / CLAUDE.md files.
+---
+
+# analyze-app-context
+
+Generate app-level context files for AI agents.
+
+## Output Contract
+
+- Produce a markdown document suitable as `AGENTS.md` / `CLAUDE.md`.
+- Include a top fenced metadata block (`yaml` preferred) containing:
+  - `name`: canonical app name
+- Include the following sections in detail:
+  - Tech Stack
+  - Architecture and Key Layers (with strict boundaries)
+  - Must-Follow Conventions (naming, file layout, module boundaries)
+  - Forbidden Patterns / Anti-Patterns
+  - Tooling and Dependency Management
+  - How to run locally (dev environment setup, key commands, configuration, external services)
+  - How to test (test types, commands, quality gates)
+  - Configuration Approach (env vars, config files, secrets handling)
+  - External Services (DB/cache/queues/APIs)
+  - Deployment and Runtime Expectations
+  - Testing and Quality Gates
+  - Common Mistakes to Avoid
+
+## Quality Bar
+
+- Keep instructions implementation-oriented and enforceable.
+- Prefer explicit constraints and examples from this app over generic best practices.
+- Do not include rules that are not supported by repository evidence.
+
+## Task-Specific Instructions
+
+- Input must be an app-level path. If no path is provided, or the path is missing/invalid, refuse and explain exactly what is wrong.
+- Treat the input path as the app scope root where output files must be written.
+- Detect vendor directories at repository root and use that signal for output files:
+  - If `.claude` exists, generate `CLAUDE.md`.
+  - If any of `.codex`, `.cursor`, `.github` exists, generate `AGENTS.md`.
+  - If none of these vendors exist, generate `AGENTS.md`.
+- Describe this app's architecture, conventions, boundaries, core commands, and testing/quality expectations.
+- Output files must be created directly at the analyzed app root (not inside `rnd/` or `r3nd/`).
+- If both files are required, keep content semantically equivalent across both files.
+
+## Infrastructure Requirements
+
+- If Dockerfile/compose infrastructure exists for this app, include:
+  - file locations
+  - base images
+  - required service containers
+  - ports
+  - health checks
+  - security constraints
+
+{{rnd/agents/shared/command-hygiene.md}}

--- a/rnd/skills/analyze-module-context/SKILL.md
+++ b/rnd/skills/analyze-module-context/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: analyze-module-context
+description: Analyze a module path and generate detailed module-level AGENTS.md / CLAUDE.md files.
+---
+
+# analyze-module-context
+
+Generate module-level context files for AI agents.
+
+## Output Contract
+
+- Generate module-level `AGENTS.md` / `CLAUDE.md` files **inside each discovered module directory**.
+- Every generated module file must start with a fenced `yaml` metadata block containing:
+  - `name`: canonical module name
+- Every generated module file must include:
+  - Module Purpose and Responsibilities
+  - Public Interfaces and Contracts
+  - Internal Architecture and Boundaries
+  - Integration Points and Dependencies
+  - Allowed Patterns and Required Conventions
+  - Forbidden Patterns / Anti-Patterns
+  - Module Commands (if applicable)
+  - Module-Specific Testing Requirements
+  - Failure Modes and Defensive Rules
+  - Common Mistakes to Avoid
+
+## Quality Bar
+
+- Optimize for maintainers working inside this module.
+- Be concrete about interfaces, invariants, and boundaries.
+- Avoid duplicating broad repo/app rules unless they directly affect this module.
+
+## Task-Specific Instructions
+
+- Input is an app/module scope path to inspect for modules. If no path is provided, or the path is missing/invalid, refuse and explain exactly what is wrong.
+- Discover module directories within the given scope and generate files per module.
+- Detect vendor directories at repository root and use that signal for output files:
+  - If `.claude` exists, generate `CLAUDE.md`.
+  - If any of `.codex`, `.cursor`, `.github` exists, generate `AGENTS.md`.
+  - If none of these vendors exist, generate `AGENTS.md`.
+- Focus on module responsibilities, public interfaces, boundaries, contracts, and module-specific testing rules.
+- Write module files inside each module directory, not at the app root.
+- Do not write a module-context `AGENTS.md`/`CLAUDE.md` at the app root for this task.
+- If both files are required, keep content semantically equivalent across both files.
+- If no module directories can be confidently identified, refuse and explain what structure is missing or ambiguous.
+{{rnd/agents/shared/command-hygiene.md}}
+{{rnd/agents/summary.md}}

--- a/rnd/skills/analyze-repo-context/SKILL.md
+++ b/rnd/skills/analyze-repo-context/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: analyze-repo-context
+description: Analyze a repository root and generate high-signal repository AGENTS.md / CLAUDE.md files with machine-readable app metadata.
+---
+
+# analyze-repo-context
+
+Generate repository-wide context files for AI agents.
+
+## Output Contract
+
+- Produce a markdown document suitable as `AGENTS.md` / `CLAUDE.md`.
+- The document must include:
+  - A fenced `yaml` block with:
+    - `apps:` list
+    - each app entry containing `name`, `path`, `purpose`, `stack`
+  - Human-readable sections:
+    - Project Overview
+    - Repo-Level Conventions
+    - Shared Tooling and Commands
+    - Cross-App Boundaries and Integration Rules
+    - Testing and Quality Gates
+    - Out of Scope
+
+## Quality Bar
+
+- Be concrete, repo-grounded, and specific to observed code and tooling.
+- Avoid generic advice; include enforceable conventions and actionable guidance.
+- Prefer short, precise rules over broad narrative.
+- If a fact is uncertain, state the uncertainty instead of inventing details.
+
+## Task-Specific Instructions
+
+- Input must be a repository-level path. If no path is provided, or the path is missing/invalid, refuse and explain exactly what is wrong.
+- Treat the input path as the scope root where output files must be written.
+- Detect vendor directories at that root:
+  - If `.claude` exists, generate `CLAUDE.md`.
+  - If any of `.codex`, `.cursor`, `.github` exists, generate `AGENTS.md`.
+  - If none of these vendors exist, generate `AGENTS.md`.
+- Generate repository-level guidance and include a machine-readable fenced metadata block (`yaml` preferred) with top-level `apps:` entries.
+- Each app entry must include: `name`, `path`, `purpose`, `stack`.
+- Keep app paths repo-relative from the analyzed scope root.
+- Output files must be created directly at the analyzed scope root (not inside `rnd/` or `r3nd/`).
+- If both files are required, keep content semantically equivalent across both files.
+- Keep the metadata block concise and valid so it can be parsed programmatically.
+
+{{rnd/agents/shared/command-hygiene.md}}


### PR DESCRIPTION
Refactors r3nd analyse to skill-driven AGENTS/CLAUDE generation, adds analyze-* skills/subcommands, removes analyse --dir, adds vendor-aware output verification, and updates tests/docs.