### PR TITLE
[codex] docs: add foundational docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ The result is a framework for moving from request to implementation in a way tha
 
 ---
 
+## 📚 Docs
+
+Start with:
+
+- [Getting Started](docs/getting-started.md)
+- [Concepts](docs/concepts.md)
+- [Workflows](docs/workflows.md)
+
+These pages cover onboarding, the repo-native model behind r3nd, and the workflow options in more detail than this landing page.
+
+---
+
 ## 🚦 Core Workflows
 
 r3nd supports four practical ways of working.
@@ -216,7 +228,7 @@ The framework is **agnostic**. You can run the same operating model on:
 
 This is **one of the core ideas** behind r3nd.
 
-By default, the durable SDLC knowledge lives under `rnd/`:
+By default, the durable SDLC knowledge lives under `r3nd/`:
 
 - `product_specs/`
 - `tech_specs/`
@@ -288,11 +300,13 @@ r3nd scaffold
 
 Update the parts that define how your team **actually works**:
 
-- `rnd/templates/*`
-- `rnd/skills/*`
-- `rnd/agents/*`
+- `r3nd/templates/*`
+- `r3nd/skills/*`
+- `r3nd/agents/*`
 - `overlays/*`
 - `AGENTS.md` / `CLAUDE.md`
+
+In this seed repository, the source content still lives under `rnd/`. The CLI maps that seed content into your configured spec directory, which is canonically `r3nd/` for generated projects.
 
 ### 5. Generate local context
 
@@ -457,11 +471,13 @@ This repository is meant to be **forked and adapted**.
 
 You should treat the markdown files as the **real product surface**:
 
-- `rnd/templates/*`
-- `rnd/skills/*`
-- `rnd/agents/*`
+- `r3nd/templates/*`
+- `r3nd/skills/*`
+- `r3nd/agents/*`
 - `overlays/*`
 - `AGENTS.md` / `CLAUDE.md`
+
+In this seed repository itself, those source files are stored under `rnd/`, but generated projects should treat `r3nd/` as the canonical spec directory unless configured otherwise.
 
 The normal adoption path is:
 
@@ -534,7 +550,7 @@ It helps with:
 
 ### Additional Canonical Workflows
 
-These are part of the shipped framework and live in `rnd/skills/`, even when you are using them through generated vendor outputs rather than the `r3nd agents` command surface.
+These are part of the shipped framework. In generated projects they live in `r3nd/skills/`, while this seed repository stores the source content under `rnd/skills/`.
 
 | Workflow | Purpose |
 |----------|---------|
@@ -557,10 +573,10 @@ r3nd analyse
 r3nd agents create-product-spec --input "User authentication system" --agent github
 
 # Create a tech spec
-r3nd agents create-tech-spec --file rnd/product_specs/auth.md --agent codex
+r3nd agents create-tech-spec --file r3nd/product_specs/auth.md --agent codex
 
 # Implement a feature from a tech spec
-r3nd agents implement-feature --file rnd/tech_specs/auth.md --agent codex
+r3nd agents implement-feature --file r3nd/tech_specs/auth.md --agent codex
 ```
 
 ---
@@ -579,7 +595,7 @@ r3nd agents implement-feature --file rnd/tech_specs/auth.md --agent codex
 
 cli/                         # Operator tooling around the framework
 
-rnd/
+rnd/                        # Seed-repo source content; copied into your configured spec dir
   agents/                    # Shared agent briefs
   templates/                 # Canonical artifact templates
   skills/                    # Canonical task skills
@@ -589,6 +605,8 @@ rnd/
   test_cases/
   retros/
   agent_summaries/
+
+r3nd/                       # Canonical generated spec directory in consumer projects
 
 overlays/                    # Stack- or domain-specific additions, including instructions
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,225 @@
+# Concepts
+
+r3nd is not just a CLI. The CLI is the operator tool around a repository-native delivery model. The framework works because the durable artifacts, rules, and execution contracts live in the repo.
+
+This page pulls the core concepts out of the root README and tightens them against the current codebase.
+
+## The Core Model
+
+r3nd combines five ideas:
+
+1. Persistent engineering knowledge in the repository
+2. Skills that encode repeatable delivery procedures
+3. Templates that constrain artifact shape
+4. Overlays that adapt the framework to a stack or domain
+5. Vendor-agnostic execution across different AI tools
+
+The result is a workflow where a request becomes a series of explicit artifacts instead of an improvised chat thread.
+
+## Repository Memory
+
+The main design claim is simple: delivery context should survive the current assistant session.
+
+That durable context lives in repo artifacts such as:
+
+- product specs
+- tech specs
+- build plans
+- test cases
+- E2E results
+- manual QA results
+- retros
+- agent summaries
+- task skills
+- templates
+- stack instructions
+
+In generated projects, those usually live under `r3nd/`.
+
+In this seed repository, the canonical source content is stored under `rnd/`, then copied or composed into the configured spec directory by the CLI.
+
+## Skills
+
+Skills are executable operating procedures. They define how a task is supposed to run, including:
+
+- purpose
+- inputs
+- outputs
+- required files
+- workflow phases
+- hard rules
+- communication constraints
+
+The current seed includes skills for:
+
+- specification work
+- implementation work
+- QA
+- retros
+- repo/app/module analysis
+- small-feature and bugfix orchestration
+
+Examples from the current seed:
+
+- `create-product-spec`
+- `create-tech-spec`
+- `create-build-plan`
+- `implement-build-plan`
+- `implement-feature`
+- `create-test-cases`
+- `run-e2e-tests`
+- `run-manual-qa-tests`
+- `create-retro-report`
+- `quick-feature`
+- `bugfix`
+
+This is why the framework is more durable than prompt snippets. The workflow contract is saved as markdown and versioned with the repo.
+
+## Agents
+
+Agents are role boundaries, not personalities.
+
+The seed uses agent briefs such as:
+
+- product manager
+- architect
+- team lead
+- developer
+- QA lead
+- E2E engineer
+- manual QA tester
+
+Skills compose those roles. For example:
+
+- `create-product-spec` uses the product-manager brief
+- `create-tech-spec` uses the architect brief
+- `create-build-plan` uses the team-lead brief
+- `implement-build-plan` uses the developer brief
+
+This keeps responsibility explicit and reduces silent role drift inside one long conversation.
+
+## Templates
+
+Templates are artifact contracts.
+
+The current seed defines templates for:
+
+- product specs
+- tech specs
+- build plans
+- test cases
+- E2E results
+- manual QA results
+- retros
+
+Templates matter because downstream steps depend on predictable structure. A weak template forces later agents to reinterpret intent. A strong template turns artifacts into stable machine- and human-readable handoff points.
+
+## Artifact Chain
+
+The normal delivery path is an artifact chain:
+
+1. Product intent becomes a product spec
+2. Product spec becomes a tech spec
+3. Tech spec becomes one or more build plans
+4. Build plans drive implementation
+5. Implementation drives test cases and QA evidence
+6. Delivery produces a retro
+
+The chain exists so implementation is grounded in approved documents instead of whatever the current chat window happens to contain.
+
+## Overlays
+
+Overlays adapt the framework to a real stack without changing the base operating model.
+
+From the current docs and CLI flow, overlays can contribute stack-specific files such as:
+
+- skills
+- instructions
+- templates
+- build plans
+- vendor assets
+
+The CLI discovers overlays from the configured seed repository and stores the chosen overlay list in `r3nd.yaml`.
+
+This is how the same framework can target different stacks without cloning the whole process by hand.
+
+## Instructions And Golden References
+
+The seed expects stack-specific rules to live in instruction files under the spec directory. The implementation and QA skills explicitly read those instructions before acting.
+
+Those instructions are used to constrain:
+
+- code patterns
+- module structure
+- validation rules
+- test frameworks
+- E2E behavior
+- runtime setup
+
+This is a critical point: the framework does not expect the model to invent local conventions. It expects the repo to state them.
+
+## Vendors Are Backends, Not Authority
+
+The framework supports multiple execution backends:
+
+- Codex
+- Claude Code
+- Gemini
+- GitHub-backed agent execution
+- prompt generation for manual use
+
+The CLI detects available tools and only offers usable options. The backend changes, but the skill, template, and artifact structure remain repo-defined.
+
+That is the actual meaning of vendor-agnostic here: execution can move, but authority stays in the repository.
+
+## Scoped Context Files
+
+r3nd supports generated context at different levels of a codebase:
+
+- repository
+- app
+- module
+
+The current analysis flow generates `AGENTS.md` and, when needed, `CLAUDE.md` at those scopes.
+
+This matters in larger repos because one global prompt file is not enough. The framework expects local context near the code that needs it.
+
+## Seed Repo Versus Generated Project
+
+There are two layers to keep straight:
+
+- The seed repository contains the source assets and currently stores them under `rnd/`
+- A consumer repository created or initialized with the CLI gets those assets under its configured spec directory, normally `r3nd/`
+
+This repo is therefore both:
+
+- the framework source
+- an example of how the source is organized before generation
+
+Confusing those two layers is the main source of documentation drift, so the docs need to keep stating it directly.
+
+## Worktrees And Parallel Delivery
+
+The framework assumes teams will run multiple efforts in parallel. The worktree support exists so parallel work still carries the same repo-native context.
+
+Current worktree behavior copies:
+
+- the configured spec directory
+- vendor directories like `.claude`, `.codex`, `.github`, `.cursor`
+- additional configured files from `worktree-copy-files`
+
+That keeps the local operating model intact inside each worktree instead of forcing re-setup for every branch.
+
+## What Adoption Really Means
+
+Cloning the repo is not adoption by itself.
+
+Actual adoption means:
+
+1. choosing the spec directory shape
+2. selecting overlays
+3. rewriting templates and skills to match your standards
+4. generating local context files
+5. running work through the artifact chain consistently
+
+If a team does not adapt the markdown, it is only trying the default seed, not establishing its own operating model.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,354 @@
+# Getting Started
+
+r3nd is a spec-driven SDLC framework. The repository is the source of truth: skills, templates, instructions, specs, plans, and QA artifacts live in version control instead of chat history.
+
+This page covers the fastest path to a usable setup based on the current CLI behavior.
+
+## What You Install
+
+The project has two layers:
+
+- The framework seed repository, which stores canonical source content under `rnd/`
+- The CLI, which copies that seed content into your configured spec directory, canonically `r3nd/`
+
+That distinction matters:
+
+- In this seed repository: source files live under `rnd/`
+- In a generated or initialized project: the CLI writes to `r3nd/` by default
+
+You can change the generated directory name through `r3nd.yaml` with `spec-dir-name`, but `r3nd/` is the documented default.
+
+## Prerequisites
+
+- Node.js `>=16`
+- Git
+
+Most users should treat the generated skills as the primary interface. That is the recommended model:
+
+- use the r3nd CLI to initialize or scaffold the repo
+- let it generate repo-native skills and templates
+- run those skills from your preferred coding agent inside the project
+
+You only need an agent backend installed if you want the CLI itself to execute agents through commands like:
+
+- `r3nd agents ...`
+- `r3nd analyse`
+
+Supported direct-execution backends are:
+
+- `codex`
+- `claude`
+- `gemini`
+- `gh` for GitHub-backed execution
+
+If you do not want the CLI to run agents directly, no agent backend is required.
+
+## Install The CLI
+
+Global install from GitHub:
+
+```bash
+sudo npm install -g git+https://github.com/leandronoijo/r3nd.git#0.3
+```
+
+Local development install:
+
+```bash
+cd cli
+npm install
+```
+
+After a global install, use `r3nd` from your shell.
+
+## Choose `init` Or `scaffold`
+
+The CLI has two setup paths.
+
+### `r3nd init`
+
+Use `init` when you want to add the framework to an existing repository with the smallest seed footprint.
+
+Current behavior from the CLI implementation:
+
+- initializes Git if `.git/` is missing
+- prompts for `seed-repo`
+- prompts for `spec-dir-name`
+- lets you choose platform asset families
+- fetches the seed tree from GitHub
+- copies common files, task skills, agent personas, templates, and base build plans
+- applies selected overlays
+- writes configuration to `r3nd.yaml`
+
+Command:
+
+```bash
+r3nd init
+```
+
+Non-interactive mode:
+
+```bash
+r3nd init -y
+```
+
+### `r3nd scaffold`
+
+Use `scaffold` when starting a new project and you want the fuller bootstrap path.
+
+Current behavior from the CLI implementation:
+
+- initializes Git if needed
+- can add `origin` during setup
+- copies the same core seed content as `init`
+- also copies testing instructions
+- ensures spec directories exist
+- applies selected overlays
+- can optionally run scaffold build plans through a supported agent backend
+
+Command:
+
+```bash
+r3nd scaffold
+```
+
+Non-interactive mode:
+
+```bash
+r3nd scaffold -y
+```
+
+Current overlay examples referenced by the docs and CLI flow:
+
+- `angular`
+- `fast-api`
+- `nestjs`
+- `ruby-on-rails`
+- `vue`
+
+## Configure The Repository
+
+Repo-level configuration lives in `r3nd.yaml`.
+
+Current supported keys:
+
+- `seed-repo`
+- `spec-dir-name`
+- `overlays`
+- `worktree-copy-files`
+- `worktree-open-command`
+
+The current CLI defaults are:
+
+```yaml
+seed-repo: leandronoijo/r3nd@develop
+spec-dir-name: r3nd
+overlays: []
+worktree-copy-files:
+  - "*.env"
+  - "**/*.env"
+worktree-open-command:
+  - code
+  - "{worktreeDir}"
+```
+
+## What Gets Generated
+
+The CLI resolves task instructions from your configured spec directory:
+
+- `r3nd/skills/`
+- `r3nd/templates/`
+- `r3nd/build_plans/`
+- `r3nd/product_specs/`
+- `r3nd/tech_specs/`
+- `r3nd/test_cases/`
+- `r3nd/e2e-results/`
+- `r3nd/retros/`
+- `r3nd/agent_summaries/`
+- `r3nd/agent_runs/`
+- `r3nd/instructions/`
+
+The exact files depend on the selected command and overlays.
+
+## Customize The Generated Framework
+
+You do not need to fork or clone the seed repository to use r3nd.
+
+The normal usage path is:
+
+1. run `r3nd init` or `r3nd scaffold` in your own repository
+2. let the CLI generate the framework files there
+3. adapt those generated files to match your team
+
+The generated framework is not meant to stay generic. Real adoption means changing the durable workflow files, especially:
+
+- `r3nd/templates/*`
+- `r3nd/skills/*`
+- `overlays/*`
+- generated `AGENTS.md` and `CLAUDE.md`
+
+In this repository itself, the source versions of those assets still live under `rnd/`.
+
+Forking or cloning the seed repository is only necessary if you want to maintain your own variant of the seed itself.
+
+It is also the recommended path for teams that treat prompts, skills, agents, and templates as controlled engineering assets. In that model:
+
+- your team keeps its own fork of the seed
+- `seed-repo` points to that fork
+- `r3nd update` pulls framework changes from your fork instead of the public upstream
+
+That gives you change control over updates to skills, agents, templates, and related framework files, instead of taking upstream prompt changes directly.
+
+## Generate Context Files
+
+r3nd supports scoped repository context generation for vendors that consume `AGENTS.md` or `CLAUDE.md`.
+
+There are two supported ways to do this:
+
+1. use the generated analysis skills inside your own coding agent
+2. use the CLI to execute analysis directly
+
+The recommended path is still the first one: generate the skills into your repo, then run them from your preferred agent.
+
+### Analysis Via Generated Skills
+
+After `init` or `scaffold`, the analysis skills live in your generated spec directory and can be run from your agent like any other r3nd skill:
+
+- `analyze-repo-context`
+- `analyze-app-context`
+- `analyze-module-context`
+
+Use them like this:
+
+- `analyze-repo-context`: generate top-level repository context
+- `analyze-app-context`: generate context for one app or service
+- `analyze-module-context`: generate context for one bounded module or area
+
+This is the recommended path when you want r3nd to provide the workflow, but you want execution to happen inside your normal coding agent session.
+
+### `r3nd analyse`
+
+This is the CLI-driven analysis flow.
+
+Current CLI behavior:
+
+1. finds the first configured spec directory in the repo
+2. runs `analyze-repo-context`
+3. reads the generated repo output
+4. parses app entries from YAML or JSON fenced blocks
+5. optionally runs `analyze-app-context` for selected apps
+6. ensures the required output files exist at each analyzed scope
+
+Command examples:
+
+```bash
+r3nd analyse
+r3nd analyse --non-interactive --agent codex
+```
+
+Supported agents for `analyse`:
+
+- `codex`
+- `claude`
+- `gemini`
+- `github`
+
+### Analysis Via `r3nd agents`
+
+You can also use the CLI to invoke the analysis skills directly by subcommand when you want a specific scope:
+
+```bash
+r3nd agents analyze-repo-context --input . --agent codex
+r3nd agents analyze-app-context --input apps/backend --agent codex
+r3nd agents analyze-module-context --input apps/backend/src/modules/auth --agent claude
+```
+
+Use them like this:
+
+- `analyze-repo-context`: top-level repository map
+- `analyze-app-context`: one app or service
+- `analyze-module-context`: one bounded area inside an app or service
+
+In short:
+
+- generated skills: recommended when you want to run analysis inside your own agent
+- `r3nd analyse`: recommended when you want the CLI to drive the broader repo/app analysis flow
+- `r3nd agents analyze-*`: recommended when you want the CLI to run one specific analysis skill directly
+
+## Start A Feature Workflow
+
+All `r3nd agents` subcommands correspond to task skills that the CLI generates into your project.
+
+That means there are two ways to use them:
+
+- run the skill directly inside your chosen coding agent, which is the recommended default
+- ask the CLI to execute that same skill through `r3nd agents ...`
+
+In other words, `r3nd agents create-product-spec` is the CLI entry point for the same `create-product-spec` skill that can also be run directly from your agent inside the repo.
+
+For a feature with explicit handoffs:
+
+```bash
+r3nd agents create-product-spec --input "Build user auth system"
+r3nd agents create-tech-spec --file r3nd/product_specs/<feature>.md --agent codex
+r3nd agents create-build-plan --file r3nd/tech_specs/<feature>.md --agent codex
+r3nd agents implement-build-plan --file r3nd/build_plans/<plan>.md --agent codex
+```
+
+For a faster feature path:
+
+```bash
+r3nd agents implement-feature --file r3nd/tech_specs/<feature>.md --agent codex
+```
+
+For monorepos or scoped work:
+
+```bash
+r3nd agents create-product-spec --spec-dir apps/backend --input "Add OAuth2" --agent github
+```
+
+That writes into `apps/backend/r3nd/` by default.
+
+## Inspect Local Tool Availability
+
+Use:
+
+```bash
+r3nd tools
+```
+
+The CLI detects installed backends and only presents usable options. If none are installed, prompt generation remains available as a fallback.
+
+## Use Worktrees For Parallel Tasks
+
+r3nd can create repo-scoped worktrees under `~/.r3nd/worktrees/`.
+
+```bash
+r3nd worktree
+r3nd worktree --branch auth-investigation
+r3nd worktree clean
+```
+
+Current behavior:
+
+- copies directories named as your configured `spec-dir-name`
+- copies vendor directories like `.claude`, `.codex`, `.github`, and `.cursor` when present
+- copies additional configured files such as `.env`
+- opens the worktree with the configured `worktree-open-command`
+
+## Recommended First Run
+
+For an existing repo:
+
+1. Run `r3nd init`
+2. Set `seed-repo`, `spec-dir-name`, and overlays
+3. Adapt templates and skills
+4. Generate repo and app context files
+5. Start with a small feature or one well-bounded spec-driven feature
+
+For a new repo:
+
+1. Run `r3nd scaffold`
+2. Select overlays and platform assets
+3. Review the generated build plans
+4. Optionally let the CLI run scaffold implementation through an agent backend
+5. Generate context files after the repo shape is stable

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,286 @@
+# Workflows
+
+r3nd supports multiple ways of working, but they all use the same underlying model: explicit artifacts, repo-defined skills, and approval boundaries that stay visible.
+
+This page maps the workflows described in the root README to the actual skills and CLI commands in the current codebase.
+
+## Workflow Selection
+
+Use the workflow that matches the size and uncertainty of the work:
+
+- full control: important, ambiguous, architectural, or high-risk work
+- semi-control: clear feature work where you still want structure
+- small feature: tightly bounded change that should stay small
+- bugfix: focused defect resolution
+
+The important distinction is not speed. It is how much artifact structure and how many approval gates the change needs.
+
+## 1. Full Control Workflow
+
+Use this when the change needs explicit handoffs and human review between stages.
+
+### Purpose
+
+- maximize traceability
+- keep architecture review explicit
+- prevent implementation from improvising from chat context
+
+### Main Skills
+
+- `create-product-spec`
+- `create-tech-spec`
+- `create-build-plan`
+- `implement-build-plan`
+- `create-test-cases`
+- `run-e2e-tests`
+- `run-manual-qa-tests`
+- `create-retro-report`
+
+### Artifact Flow
+
+1. `product_specs/`
+2. `tech_specs/`
+3. `build_plans/`
+4. code and tests in the app
+5. `test_cases/`
+6. `e2e-results/`
+7. `manual-qa-results/`
+8. `retros/`
+
+### Approval Boundaries
+
+- after product spec
+- after tech spec
+- after build plan
+- after implementation and QA evidence
+- after retro, if you use retro-driven process improvement
+
+### CLI Example
+
+```bash
+r3nd agents create-product-spec --input "Build user authentication"
+r3nd agents create-tech-spec --file r3nd/product_specs/<feature>.md --agent codex
+r3nd agents create-build-plan --file r3nd/tech_specs/<feature>.md --agent codex
+r3nd agents implement-build-plan --file r3nd/build_plans/<feature>-T1-build-plan.md --agent codex
+r3nd agents create-test-cases --file r3nd/build_plans/<feature>-T1-build-plan.md --agent codex
+r3nd agents run-e2e-tests --file r3nd/test_cases/<feature>.md --agent codex
+r3nd agents create-retro-report --input "<pr-url-or-number>" --agent github
+```
+
+### Notes From The Current Skills
+
+- `create-tech-spec` is grounded in the existing repo and instruction files
+- `create-build-plan` creates one build plan per task from the tech spec
+- `implement-build-plan` treats the build plan as the source of truth and updates task checkboxes
+- `run-e2e-tests` writes result reports to `e2e-results/`
+- `run-manual-qa-tests` is the live-evidence gate and writes into `manual-qa-results/`
+
+## 2. Semi-Control Workflow
+
+Use this when the product direction is already clear and you want fewer handoffs without dropping artifact discipline.
+
+### Purpose
+
+- move faster than the full chain
+- keep technical direction explicit
+- still verify work through structured implementation and QA
+
+### Main Skills
+
+- `create-tech-spec`
+- `implement-feature`
+
+### How It Works
+
+`implement-feature` is the orchestrated path. In the current registry and skill set, it:
+
+- starts from a tech spec or feature directory
+- enforces build-plan assurance
+- runs dependency-aware implementation
+- writes required run artifacts under `agent_runs/`
+- requires final E2E QA
+
+### Approval Boundaries
+
+- after the tech spec
+- after the feature implementation and QA evidence
+
+### CLI Example
+
+```bash
+r3nd agents create-tech-spec --file r3nd/product_specs/<feature>.md --agent codex
+r3nd agents implement-feature --file r3nd/tech_specs/<feature>.md --agent codex
+```
+
+### When To Prefer It
+
+- product intent is already agreed
+- architecture still matters
+- you want the LLM to manage task sequencing without manually invoking every stage
+
+## 3. Small Feature Workflow
+
+Use this for very small, local changes that should not expand into a multi-artifact delivery chain.
+
+### Main Skill
+
+- `quick-feature`
+
+### What Makes It Different
+
+The `quick-feature` skill is stricter than the README summary implies. It is not just a shorthand implementation path. The skill defines a phase-based workflow with:
+
+1. investigation
+2. eligibility gate
+3. one single `T1` build plan
+4. explicit user approval before coding
+5. implementation
+6. QA
+
+### Hard Limits In The Skill
+
+The quick path is meant to stay narrow. The skill rejects work that is:
+
+- architectural
+- ambiguous
+- broad enough to need multiple task tracks
+- likely to require a larger workflow
+
+The plan is required to stay as exactly one build plan:
+
+- `rnd/build_plans/<feature-id>-T1-build-plan.md`
+
+### Approval Boundary
+
+The skill explicitly requires this question before implementation:
+
+`Do you approve this build plan and want me to implement it now? (yes/no)`
+
+### Practical Meaning
+
+Use this path when the correct change is small enough that a full product-spec and tech-spec chain would mostly add ceremony, but you still want:
+
+- an explicit plan
+- a stop/go approval point
+- implementation discipline
+- live verification
+
+## 4. Bugfix Workflow
+
+Use this for focused defect repair where understanding the failure is more important than producing a new design artifact chain.
+
+### Main Skill
+
+- `bugfix`
+
+### Required Phases In The Skill
+
+The current `bugfix` skill defines these phases:
+
+1. reproduction gate
+2. investigation
+3. plan review
+4. implementation
+5. verification
+6. documentation follow-up
+
+### What The Skill Enforces
+
+- reproduce the bug before editing whenever possible
+- inspect current code and relevant history
+- separate intended behavior from regression
+- present a minimal fix proposal before coding
+- rerun the repro path after the fix
+
+This is materially more disciplined than “just patch the bug.”
+
+### Approval Boundary
+
+- after diagnosis and minimal fix proposal
+- after verification evidence
+
+### Practical Meaning
+
+Use this workflow when the core question is:
+
+“What is the smallest safe change that restores intended behavior?”
+
+Do not use it for redesigns disguised as bug reports.
+
+## Analysis Workflow
+
+There is also a context-generation workflow that supports the other delivery paths.
+
+### Skills
+
+- `analyze-repo-context`
+- `analyze-app-context`
+- `analyze-module-context`
+
+### CLI Paths
+
+High-level:
+
+```bash
+r3nd analyse --agent codex
+```
+
+Direct:
+
+```bash
+r3nd agents analyze-repo-context --input . --agent codex
+r3nd agents analyze-app-context --input apps/backend --agent codex
+r3nd agents analyze-module-context --input apps/backend/src/modules/auth --agent claude
+```
+
+### Purpose
+
+- generate repo-scoped operating context
+- keep context files close to the code they govern
+- support large repos without relying on one global prompt file
+
+This workflow usually happens before or alongside feature work, not after delivery starts.
+
+## Choosing The Right Approval Model
+
+A simple rule set:
+
+- if product behavior is unclear: use full control
+- if product behavior is clear but technical shape matters: use semi-control
+- if the change is truly small and local: use small feature
+- if the problem is broken existing behavior: use bugfix
+
+The mistake to avoid is using the fastest-looking workflow for work that is actually ambiguous or structural. That just moves design cost into implementation and QA.
+
+## Output Directories By Workflow
+
+Common directories used by the current workflows:
+
+- `product_specs/`
+- `tech_specs/`
+- `build_plans/`
+- `test_cases/`
+- `e2e-results/`
+- `manual-qa-results/`
+- `retros/`
+- `agent_summaries/`
+- `agent_runs/`
+
+Not every workflow uses every directory:
+
+- full control uses most of them
+- semi-control usually starts at `tech_specs/`
+- small feature may only require one build plan plus QA artifacts
+- bugfix may not require a new spec, but still expects repro and verification evidence
+
+## Monorepo Note
+
+All of these workflows can run against a scoped spec directory with `--spec-dir`.
+
+Example:
+
+```bash
+r3nd agents create-product-spec --spec-dir apps/backend --input "Add OAuth2" --agent github
+```
+
+That writes artifacts under `apps/backend/r3nd/` when `spec-dir-name` is left at the default.


### PR DESCRIPTION
## Summary
- add foundational docs for getting started, concepts, and workflows
- link the root README to those new docs
- keep the PR scoped to README plus the three new docs only

## Validation
- reviewed the staged diff for `README.md`, `docs/getting-started.md`, `docs/concepts.md`, and `docs/workflows.md`
