### PR TITLE
[codex] Update instruction file references

### DIFF
--- a/rnd/skills/bugfix/SKILL.md
+++ b/rnd/skills/bugfix/SKILL.md
@@ -25,7 +25,7 @@ This workflow is for regressions, not redesigns. The job is to understand why th
 4. **Minimal fix wins** - Prefer the smallest change that restores correctness without redesigning the feature.
 5. **Plan before implementation** - Show the diagnosis and proposed fix to the user before coding.
 6. **Verify after implementation** - Re-run the same repro path and targeted checks after the fix lands.
-7. **Developer standards still apply** - Once implementation starts, follow `rnd/agents/developer.md` and the relevant `rnd/instructions/*.instructions.md` files.
+7. **Developer standards still apply** - Once implementation starts, follow `rnd/agents/developer.md` and the applicable `AGENTS.md` / `CLAUDE.md` files.
 
 Ask yourself before changing code: *Do I understand the failure, the original intent, and the narrowest safe fix?*
 
@@ -83,7 +83,7 @@ Separate context required.
 No phase-specific skill exists.
 Use agent brief: `rnd/agents/developer.md`
 
-6. Inspect the failing path, nearby tests, and any matching `rnd/instructions/*.instructions.md` files before editing.
+6. Inspect the failing path, nearby tests, and any matching `AGENTS.md` / `CLAUDE.md` files before editing.
 7. Use commit history to identify the likely change that introduced the regression and the intent behind it.
 8. If `rnd/tech_specs/` or `rnd/build_plans/` contain relevant context, read the matching files and separate intended behavior from accidental behavior.
 9. Keep the investigation narrow: focus on the smallest set of files that plausibly owns the bug.
@@ -140,7 +140,7 @@ Use agent brief: `rnd/agents/developer.md`
 | Bug report | User prompt, issue link, stack trace, or observed failure | Starting point for reproduction |
 | Codebase | Current repository | Failure path and integration points |
 | Git history | Current repository history | Intent behind the regression |
-| Repo instructions | `rnd/instructions/*.instructions.md` | Stack-specific conventions and test rules |
+| Repo instructions | applicable `AGENTS.md` / `CLAUDE.md` files | Stack-specific conventions and test rules |
 | Specs and plans | `rnd/tech_specs/` and `rnd/build_plans/` when present | Intended behavior and scope boundaries |
 
 ## Outputs

--- a/rnd/skills/create-build-plan/SKILL.md
+++ b/rnd/skills/create-build-plan/SKILL.md
@@ -24,7 +24,7 @@ Turn a technical spec or concrete problem statement into a concrete implementati
 | Technical Spec | `rnd/tech_specs/<feature-id>-tech-spec.md` | Source of truth for the work and task breakdown |
 | Existing Code | Current codebase | Integration points and golden references |
 | Existing Tests | Current codebase test locations | Test structure and coverage patterns |
-| Stack Rules | `rnd/instructions/` | Relevant conventions for the affected areas |
+| Stack Rules | repo/app/module-scoped `AGENTS.md` / `CLAUDE.md` files | Relevant conventions for the affected areas |
 | Architecture Docs | Current codebase documentation | System context and constraints |
 
 ## Outputs
@@ -56,7 +56,7 @@ Use `rnd/templates/build_plan.md` exactly and fill in the task-specific placehol
 
 - Verify dependencies from previous tasks are complete.
 - Identify integration points in the technical spec.
-- Read matching instruction files in `rnd/instructions/`.
+- Read the repo/app/module-scoped `AGENTS.md` / `CLAUDE.md` files that match the affected areas.
 - Identify golden reference modules to follow.
 - Confirm no new dependencies are needed unless justified.
 - Review interfaces this task exposes or consumes.
@@ -139,7 +139,7 @@ Use `rnd/templates/build_plan.md` exactly and fill in the task-specific placehol
 
 ## File I/O and Scope
 
-- Read `rnd/tech_specs/`, the current codebase, and `rnd/instructions/`.
+- Read `rnd/tech_specs/`, the current codebase, and repo/app/module-scoped `AGENTS.md` / `CLAUDE.md` files.
 - Write `rnd/build_plans/` only.
 
 ## Communication Style

--- a/rnd/skills/create-retro-report/SKILL.md
+++ b/rnd/skills/create-retro-report/SKILL.md
@@ -22,7 +22,7 @@ Review PR discussion and identify concrete improvements to this repo's agents, t
 | PR files | PR file list | Map feedback to directories and process assets |
 | Agent profiles | `rnd/agents/*.md` | Update guidance for agents |
 | Templates | `rnd/templates/*.md` | Update guidance for templates |
-| Instructions | `rnd/instructions/*.instructions.md` | Update execution rules |
+| Instructions | applicable `AGENTS.md` / `CLAUDE.md` files | Update execution rules |
 
 ## Outputs
 
@@ -44,13 +44,13 @@ Use the file path referenced in a comment to determine which process artifact to
 | `rnd/tech_specs/` | `architect` agent + `rnd/templates/tech_spec.md` |
 | `rnd/build_plans/` | `team-lead` agent + `rnd/templates/build_plan.md` |
 | `rnd/test_cases/` | `qa-team-lead` agent + `rnd/templates/test_cases.md` |
-| E2E artifacts in the current codebase or `rnd/e2e-results/` | `e2e-engineer` agent + `rnd/instructions/e2e-testing.instructions.md` + `rnd/templates/e2e-result.md` |
-| Backend application code paths in the current codebase | `developer` agent + `rnd/instructions/backend.instructions.md` |
-| Frontend application code paths in the current codebase | `developer` agent + `rnd/instructions/frontend.instructions.md` |
-| Automated test paths in the current codebase | `developer` agent + `rnd/instructions/testing.instructions.md` |
+| E2E artifacts in the current codebase or `rnd/e2e-results/` | `e2e-engineer` agent + the E2E testing guidance in the applicable `AGENTS.md` / `CLAUDE.md` + `rnd/templates/e2e-result.md` |
+| Backend application code paths in the current codebase | `developer` agent + the backend guidance in the applicable `AGENTS.md` / `CLAUDE.md` |
+| Frontend application code paths in the current codebase | `developer` agent + the frontend guidance in the applicable `AGENTS.md` / `CLAUDE.md` |
+| Automated test paths in the current codebase | `developer` agent + the testing guidance in the applicable `AGENTS.md` / `CLAUDE.md` |
 | `rnd/agents/` | The referenced agent profile |
 | `rnd/templates/` | The referenced template |
-| `rnd/instructions/` | The referenced instruction file |
+| repo/app/module-scoped `AGENTS.md` / `CLAUDE.md` files | The referenced instruction file or scoped rule |
 
 If a comment does not reference a file path, use the PR scope and discussion context to choose the most relevant artifact and state the assumption in the retro.
 

--- a/rnd/skills/create-tech-spec/SKILL.md
+++ b/rnd/skills/create-tech-spec/SKILL.md
@@ -29,7 +29,7 @@ The skill supports two input modes. Use exactly one per invocation.
 ### Both Modes Also Use
 
 - Repository sources across the current codebase for context.
-- `rnd/instructions/` for stack and tooling guidance.
+- repo/app/module-scoped `AGENTS.md` / `CLAUDE.md` files for stack and tooling guidance.
 - `rnd/templates/tech_spec.md` as the canonical template.
 
 ## Outputs
@@ -74,7 +74,7 @@ The final spec must include:
 ## Behavior & Rules
 
 - Always read `rnd/templates/tech_spec.md` and use it as the canonical starting point.
-- Always follow repository-level instructions and any path-specific `rnd/instructions/*.instructions.md`.
+- Always follow repository-level instructions and any applicable path-specific `AGENTS.md` / `CLAUDE.md` files.
 - Ground the design in the current repo layout and cite real files or modules that exist.
 - Verify referenced repository files exist before naming them in the spec.
 - Do not modify `rnd/templates/tech_spec.md`.
@@ -102,9 +102,9 @@ Use concise, delta-oriented writing.
 
 Before drafting any technical specification, perform these checks.
 
-### Step 1: List Available Instruction Files
+### Step 1: Find Available Instruction Files
 
-- List all files in `rnd/instructions/` before designing the spec.
+- Find repo/app/module-scoped `AGENTS.md` / `CLAUDE.md` files before designing the spec.
 
 ### Step 2: Identify Target Directories
 
@@ -117,11 +117,11 @@ Before drafting any technical specification, perform these checks.
 
 ### Step 3: Check for Matching Instructions
 
-- For each target directory, check whether a matching instruction file exists.
+- For each target directory, check whether a matching scoped instruction file exists.
 - Examples:
-  - `backend` directory -> `backend.instructions.md`
-  - `frontend` directory -> `frontend.instructions.md`
-  - custom directories -> `<directory-name>.instructions.md`
+  - backend changes -> nearest backend app/module `AGENTS.md` / `CLAUDE.md`
+  - frontend changes -> nearest frontend app/module `AGENTS.md` / `CLAUDE.md`
+  - cross-cutting changes -> repository-level `AGENTS.md` / `CLAUDE.md`
 
 ### Step 4: Warn and Prompt User
 

--- a/rnd/skills/create-test-cases/SKILL.md
+++ b/rnd/skills/create-test-cases/SKILL.md
@@ -15,7 +15,7 @@ Produce clear, actionable end-to-end sanity test cases for a feature and write t
 - `rnd/product_specs/<feature-id>-product-spec.md` (required)
 - `rnd/tech_specs/<feature-id>-tech-spec.md` (required if present)
 - `rnd/build_plans/<feature-id>-build-plan.md` (recommended)
-- Repository sources for touched modules, guided by `rnd/instructions/`
+- Repository sources for touched modules, guided by repo/app/module-scoped `AGENTS.md` / `CLAUDE.md` files
 
 ## Outputs
 
@@ -48,7 +48,7 @@ Produce clear, actionable end-to-end sanity test cases for a feature and write t
 
 ## File I/O and Scope
 
-- Read: `rnd/product_specs/`, `rnd/tech_specs/`, `rnd/build_plans/`, the current codebase, and `rnd/instructions/`
+- Read: `rnd/product_specs/`, `rnd/tech_specs/`, `rnd/build_plans/`, the current codebase, and repo/app/module-scoped `AGENTS.md` / `CLAUDE.md` files
 - Write: `rnd/test_cases/<feature-id>-test-cases.md` only
 - If the product spec is missing or ambiguous, stop and ask for clarification rather than guessing the feature id
 

--- a/rnd/skills/implement-build-plan/SKILL.md
+++ b/rnd/skills/implement-build-plan/SKILL.md
@@ -22,8 +22,8 @@ Implement features and tests based on a build plan; follow repository standards 
 | Input | Location | Purpose |
 |-------|----------|---------|
 | Build Plan | `rnd/build_plans/<feature-id>-build-plan.md` | Source of truth for the task |
-| Backend Rules | `rnd/instructions/backend.instructions.md` | Backend conventions and code patterns |
-| Frontend Rules | `rnd/instructions/frontend.instructions.md` | Frontend conventions and code patterns |
+| Backend Rules | the backend guidance in the applicable `AGENTS.md` / `CLAUDE.md` | Backend conventions and code patterns |
+| Frontend Rules | the frontend guidance in the applicable `AGENTS.md` / `CLAUDE.md` | Frontend conventions and code patterns |
 | Existing Code | Current codebase | Context and integration points |
 | Existing Tests | Current codebase test locations | Test patterns and coverage expectations |
 | Golden References | As specified in the build plan | Canonical examples to copy |
@@ -102,7 +102,7 @@ Implement features and tests based on a build plan; follow repository standards 
 ### Golden References
 
 - Use the repository's example modules, services, controllers, DTOs, schemas, components, stores, and tests as the canonical patterns.
-- Use `rnd/instructions/` to locate the correct references for the stack in play.
+- Use repo/app/module-scoped `AGENTS.md` / `CLAUDE.md` files to locate the correct references for the stack in play.
 - Do not invent new patterns when a repository example already exists.
 
 ## File I/O and Scope
@@ -111,7 +111,7 @@ Implement features and tests based on a build plan; follow repository standards 
 |--------|-----------|---------|
 | Read | `rnd/build_plans/` | Task source of truth |
 | Read | Current codebase | Implementation context |
-| Read | `rnd/instructions/` | Stack rules and patterns |
+| Read | repo/app/module-scoped `AGENTS.md` / `CLAUDE.md` files | Stack rules and patterns |
 | Write | Current codebase application code locations | Implementation code |
 | Write | Current codebase test locations | Test code |
 | Write | `rnd/build_plans/` | Checkbox updates and clarifications |
@@ -122,7 +122,7 @@ Implement features and tests based on a build plan; follow repository standards 
 - `rnd/product_specs/`.
 - `rnd/tech_specs/`.
 - `.github/workflows/`.
-- `rnd/instructions/`.
+- repo/app/module-scoped `AGENTS.md` / `CLAUDE.md` files.
 
 ## Common Mistakes to Avoid
 

--- a/rnd/skills/implement-feature/SKILL.md
+++ b/rnd/skills/implement-feature/SKILL.md
@@ -20,7 +20,7 @@ Drive a feature from tech spec to verified implementation by coordinating build-
 - Feature directory with the matching spec artifacts
 - Build plans: one `-T<n>-build-plan.md` file per task
 - Optional test cases: `rnd/test_cases/...`
-- Current codebase, tests, and relevant `rnd/instructions/` files
+- Current codebase, tests, and relevant repo/app/module-scoped `AGENTS.md` / `CLAUDE.md` files
 
 ## Outputs
 
@@ -97,7 +97,7 @@ No distinct agent brief exists.
 
 1. Resolve the feature id and locate the tech spec.
 2. Locate the feature build plans and any existing test-case files.
-3. Read the current codebase and relevant `rnd/instructions/` files before scheduling work.
+3. Read the current codebase and relevant repo/app/module-scoped `AGENTS.md` / `CLAUDE.md` files before scheduling work.
 
 ### 2. Build-Plan Assurance
 
@@ -191,7 +191,7 @@ On task-gate or final live-QA failure:
 
 ## File I/O and Scope
 
-- Read `rnd/tech_specs/`, `rnd/build_plans/`, `rnd/test_cases/`, the current codebase, and `rnd/instructions/`.
+- Read `rnd/tech_specs/`, `rnd/build_plans/`, `rnd/test_cases/`, the current codebase, and repo/app/module-scoped `AGENTS.md` / `CLAUDE.md` files.
 - Write implementation artifacts only under `rnd/agent_runs/<feature-id>/implement-feature-<timestamp>/`.
 - Use `rnd/manual-qa-results/` for the final live-QA report and artifacts.
 - Do not skip build-plan generation, task QA, or final live QA.

--- a/rnd/skills/quick-feature/SKILL.md
+++ b/rnd/skills/quick-feature/SKILL.md
@@ -17,7 +17,7 @@ Keep tiny feature work tiny. If the request needs structural refactoring, multi-
 
 - User request or feature description
 - Current repository code and tests
-- `rnd/instructions/` files relevant to the touched area
+- repo/app/module-scoped `AGENTS.md` / `CLAUDE.md` files relevant to the touched area
 - `rnd/templates/build_plan.md`
 - `rnd/templates/test_cases.md` when written checks are needed
 
@@ -144,7 +144,7 @@ Fallback teammate briefs: `rnd/agents/qa-team-lead.md`, `rnd/agents/e2e-engineer
 
 ## File I/O and Scope
 
-- Read: the current codebase, `rnd/instructions/`, and the repo templates needed for the task.
+- Read: the current codebase, repo/app/module-scoped `AGENTS.md` / `CLAUDE.md` files, and the repo templates needed for the task.
 - Write: `rnd/build_plans/`, current codebase files, `rnd/test_cases/` when needed, `rnd/manual-qa-results/` for final live QA, and `rnd/agent_summaries/` when the user is satisfied.
 - Do not modify unrelated files or expand the scope beyond the approved quick feature.
 

--- a/rnd/skills/run-e2e-tests/SKILL.md
+++ b/rnd/skills/run-e2e-tests/SKILL.md
@@ -14,8 +14,8 @@ Generate, execute, diagnose, and report end-to-end tests derived from `rnd/test_
 
 - `rnd/test_cases/<feature-id>-test-cases.md` (required)
 - `rnd/build_plans/<feature-id>-build-plan.md` (required for selectors, contracts, and acceptance criteria)
-- `rnd/instructions/e2e-testing.instructions.md`
-- `rnd/instructions/testing.instructions.md`
+- the E2E testing guidance in the applicable `AGENTS.md` / `CLAUDE.md`
+- the testing guidance in the applicable `AGENTS.md` / `CLAUDE.md`
 - Implemented code in the current codebase
 
 ## Outputs
@@ -44,7 +44,7 @@ Generate, execute, diagnose, and report end-to-end tests derived from `rnd/test_
 ### Phase 3: Test Generation
 
 1. Map each test case to one executable test file, unless related cases can share fixtures safely.
-2. Use the framework and patterns specified in `rnd/instructions/e2e-testing.instructions.md`.
+2. Use the framework and patterns specified in the E2E testing guidance in the applicable `AGENTS.md` / `CLAUDE.md`.
 3. Prefer `data-test-id` selectors, explicit waits, and AAA structure.
 4. Keep tests independent and stable.
 
@@ -68,7 +68,7 @@ Generate, execute, diagnose, and report end-to-end tests derived from `rnd/test_
 
 ## Hard Rules
 
-- Use only the framework and patterns from `rnd/instructions/e2e-testing.instructions.md`.
+- Use only the framework and patterns from the E2E testing guidance in the applicable `AGENTS.md` / `CLAUDE.md`.
 - Use only `data-test-id` selectors.
 - Run tests sequentially.
 - Keep the startup timeout to 10 minutes.
@@ -84,7 +84,7 @@ Generate, execute, diagnose, and report end-to-end tests derived from `rnd/test_
 
 ## File I/O and Scope
 
-- Read: `rnd/test_cases/`, `rnd/build_plans/`, the current codebase, `rnd/instructions/e2e-testing.instructions.md`, and `rnd/instructions/testing.instructions.md`
+- Read: `rnd/test_cases/`, `rnd/build_plans/`, the current codebase, the E2E testing guidance in the applicable `AGENTS.md` / `CLAUDE.md`, and the testing guidance in the applicable `AGENTS.md` / `CLAUDE.md`
 - Write: E2E test files, fixtures, result reports, and failure artifacts in the current codebase or `rnd/e2e-results/`
 - Do not start services manually when a compose-based workflow is available
 

--- a/rnd/skills/run-manual-qa-tests/SKILL.md
+++ b/rnd/skills/run-manual-qa-tests/SKILL.md
@@ -22,7 +22,7 @@ This skill is the final evidence gate for live verification. Unit tests, integra
 - Inline custom repro case from a parent skill when no saved test-case file exists
 - Relevant build plans under `rnd/build_plans/`
 - Optional product spec and tech spec under `rnd/product_specs/` and `rnd/tech_specs/`
-- Relevant `rnd/instructions/*.instructions.md` files
+- Relevant `AGENTS.md` / `CLAUDE.md` files
 - `rnd/templates/manual-qa-result.md`
 - Current codebase, runtime scripts, test accounts, and observable side-effect tooling
 
@@ -44,7 +44,7 @@ This skill is the final evidence gate for live verification. Unit tests, integra
 ### 1. Context and Scope
 
 1. Read the written test cases or the inline repro case.
-2. Read the relevant build plans, specs, and `rnd/instructions/` files.
+2. Read the relevant build plans, specs, and repo/app/module-scoped `AGENTS.md` / `CLAUDE.md` files.
 3. Open `rnd/templates/manual-qa-result.md` and use it as the report structure.
 4. Identify the observable artifacts needed for each case.
 
@@ -86,7 +86,7 @@ When a parent skill sends a single inline reproduction case:
 
 ## File I/O and Scope
 
-- Read: `rnd/test_cases/`, `rnd/build_plans/`, `rnd/product_specs/`, `rnd/tech_specs/`, `rnd/instructions/`, `rnd/templates/manual-qa-result.md`, and the current codebase
+- Read: `rnd/test_cases/`, `rnd/build_plans/`, `rnd/product_specs/`, `rnd/tech_specs/`, repo/app/module-scoped `AGENTS.md` / `CLAUDE.md` files, `rnd/templates/manual-qa-result.md`, and the current codebase
 - Write: `rnd/manual-qa-results/` only
 - Do not approve behavior without fresh artifacts from the current run
 

--- a/rnd/templates/build_plan.md
+++ b/rnd/templates/build_plan.md
@@ -29,11 +29,11 @@ Complete these items **before** starting any implementation tasks.
 
 - [ ] **Verify previous task dependencies are complete** (if T>1)
 - [ ] Identify integration points in Section 1
-- [ ] Read instruction files in `rnd/instructions/` that match those integration points
-  - Example: backend changes → `backend.instructions.md` (if present)
-  - Example: frontend changes → `frontend.instructions.md` (if present)
-  - Example: testing changes → `testing.instructions.md`
-  - Example: e2e changes → `e2e-testing.instructions.md`
+- [ ] Read repo/app/module-scoped `AGENTS.md` / `CLAUDE.md` files that match those integration points
+  - Example: backend changes -> nearest backend app/module instruction file
+  - Example: frontend changes -> nearest frontend app/module instruction file
+  - Example: testing changes -> testing guidance in the applicable scoped instruction file
+  - Example: e2e changes -> E2E guidance in the applicable scoped instruction file
 - [ ] Identify golden reference modules:
   - Backend: `src/backend/modules/example/`
   - Frontend: `src/frontend/components/example/`, `src/frontend/stores/exampleStore.ts`
@@ -91,7 +91,7 @@ Complete these items **before** starting any implementation tasks.
 - **Dependencies:** None
 - **Golden Reference:** `src/backend/modules/example/schemas/example.schema.ts`
 - **Details:**
-  - Define schema/model using the backend data modeling approach specified in `rnd/instructions/backend.instructions.md`.
+  - Define schema/model using the backend data modeling approach specified in the backend guidance in the applicable `AGENTS.md` / `CLAUDE.md`.
   - Fields (example):
     - `fieldName: string` — required
     - `optionalField?: string` — optional
@@ -114,7 +114,7 @@ Complete these items **before** starting any implementation tasks.
 - **Dependencies:** Step 1
 - **Golden Reference:** `src/backend/modules/example/dto/create-example.dto.ts`
 - **Details:**
-  - Class with validation decorators/annotations (follow `rnd/instructions/backend.instructions.md` for examples)
+  - Class with validation decorators/annotations (follow the backend guidance in the applicable `AGENTS.md` / `CLAUDE.md` for examples)
   - Field names must match schema exactly
 - **Acceptance Criteria:**
   - All fields have appropriate validation decorators/annotations as defined in backend instructions
@@ -145,7 +145,7 @@ Complete these items **before** starting any implementation tasks.
 - **Dependencies:** Step 1, Step 2
 - **Golden Reference:** `src/backend/modules/example/example.service.ts`
 - **Details:**
-  - Class registered as a service per backend DI conventions (see `rnd/instructions/backend.instructions.md`)
+  - Class registered as a service per backend DI conventions (see the backend guidance in the applicable `AGENTS.md` / `CLAUDE.md`)
   - Inject repository/model via repository DI provider pattern per backend instructions
   - Methods:
     - `async create(dto: CreateEntityDto): Promise<Entity>`
@@ -198,7 +198,7 @@ Complete these items **before** starting any implementation tasks.
 - **Dependencies:** Step 1, Step 3, Step 4
 - **Golden Reference:** `src/backend/modules/example/example.module.ts`
 - **Details:**
-  - Register the model/provider according to backend module conventions (see `rnd/instructions/backend.instructions.md`)
+  - Register the model/provider according to backend module conventions (see the backend guidance in the applicable `AGENTS.md` / `CLAUDE.md`)
   - Declare controller in `controllers`
   - Declare service in `providers`
   - Export service if other modules need it
@@ -231,7 +231,7 @@ Complete these items **before** starting any implementation tasks.
 - **Dependencies:** Step 3
 - **Golden Reference:** `src/backend/modules/example/example.service.spec.ts`
 - **Details:**
-  - Use the repository's backend testing harness and patterns (see `rnd/instructions/testing.instructions.md`)
+  - Use the repository's backend testing harness and patterns (see the testing guidance in the applicable `AGENTS.md` / `CLAUDE.md`)
   - Mock `Model<Entity>` for all methods
   - Test cases:
     - `create()` — returns saved entity
@@ -303,17 +303,17 @@ Complete these items **before** starting any implementation tasks.
 - **Dependencies:** Step 7
 -- **Golden Reference:** `src/frontend/components/example/ExampleList` (component file)
 - **Details:**
-  - Use the frontend component pattern/syntax as defined in `rnd/instructions/frontend.instructions.md`
-  - Import and use the repository's store pattern per `rnd/instructions/frontend.instructions.md`
-  - UI components: use repository's selected UI library components (see `rnd/instructions/frontend.instructions.md`)
+  - Use the frontend component pattern/syntax as defined in the frontend guidance in the applicable `AGENTS.md` / `CLAUDE.md`
+  - Import and use the repository's store pattern per the frontend guidance in the applicable `AGENTS.md` / `CLAUDE.md`
+  - UI components: use repository's selected UI library components (see the frontend guidance in the applicable `AGENTS.md` / `CLAUDE.md`)
   - Required `data-test-id` attributes:
     - `entity-list-container`
     - `entity-list-item-{id}`
     - `entity-list-loading`
     - `entity-list-empty`
 - **Acceptance Criteria:**
-  - Frontend component pattern: use composition-style components as defined in `rnd/instructions/frontend.instructions.md`
-  - Use the repository's designated UI library and follow its component patterns (see `rnd/instructions/frontend.instructions.md`)
+  - Frontend component pattern: use composition-style components as defined in the frontend guidance in the applicable `AGENTS.md` / `CLAUDE.md`
+  - Use the repository's designated UI library and follow its component patterns (see the frontend guidance in the applicable `AGENTS.md` / `CLAUDE.md`)
   - All interactive elements have `data-test-id`
   - Fetches data via store on mount
 - **Effort:** medium
@@ -325,10 +325,10 @@ Complete these items **before** starting any implementation tasks.
 - **Action:** create
 - **Dependencies:** Step 7
 - **Details:**
-  - Use the frontend component pattern/syntax as defined in `rnd/instructions/frontend.instructions.md`
+  - Use the frontend component pattern/syntax as defined in the frontend guidance in the applicable `AGENTS.md` / `CLAUDE.md`
   - Props: `entity?: Entity` (for edit mode), `mode: 'create' | 'edit'`
   - Emits: `submit`, `cancel`
-  - UI form components per `rnd/instructions/frontend.instructions.md` (use the repo's designated UI library)
+  - UI form components per the frontend guidance in the applicable `AGENTS.md` / `CLAUDE.md` (use the repo's designated UI library)
   - Client-side validation matching backend DTOs
   - Required `data-test-id` attributes:
     - `entity-form`
@@ -405,7 +405,7 @@ Complete these items **before** starting any implementation tasks.
 - **Action:** create
 - **Dependencies:** Step 7
 - **Details:**
-  - Use the repository's frontend store test harness (see `rnd/instructions/testing.instructions.md`)
+  - Use the repository's frontend store test harness (see the testing guidance in the applicable `AGENTS.md` / `CLAUDE.md`)
   - Mock API calls
   - Test all actions and state mutations
 - **Acceptance Criteria:**
@@ -420,8 +420,8 @@ Complete these items **before** starting any implementation tasks.
 - **Action:** create
 - **Dependencies:** Step 8
 - **Details:**
-  - Use the repository's frontend testing utilities and patterns (see `rnd/instructions/testing.instructions.md`)
-  - Mock store using the repository's frontend testing harness (see `rnd/instructions/testing.instructions.md`)
+  - Use the repository's frontend testing utilities and patterns (see the testing guidance in the applicable `AGENTS.md` / `CLAUDE.md`)
+  - Mock store using the repository's frontend testing harness (see the testing guidance in the applicable `AGENTS.md` / `CLAUDE.md`)
   - Test rendering, interactions
 - **Acceptance Criteria:**
   - Components render correctly
@@ -544,10 +544,10 @@ Complete these items **before** starting any implementation tasks.
 
 | Area | Warning | Correct Pattern |
 |------|---------|-----------------|
-| **Frontend** | Follow `rnd/instructions/frontend.instructions.md` for frontend patterns and allowed libraries. | See frontend instructions |
-| **Backend** | Follow `rnd/instructions/backend.instructions.md` for backend patterns and allowed libraries. | See backend instructions |
+| **Frontend** | Follow the frontend guidance in the applicable `AGENTS.md` / `CLAUDE.md` for frontend patterns and allowed libraries. | See frontend instructions |
+| **Backend** | Follow the backend guidance in the applicable `AGENTS.md` / `CLAUDE.md` for backend patterns and allowed libraries. | See backend instructions |
 | **DTOs** | Follow backend instructions for DTOs, validation, and schema sync. | See backend instructions |
-| **Tests** | Follow `rnd/instructions/testing.instructions.md` for test requirements, selectors/doc conventions, and quality gates. | See testing instructions |
+| **Tests** | Follow the testing guidance in the applicable `AGENTS.md` / `CLAUDE.md` for test requirements, selectors/doc conventions, and quality gates. | See testing instructions |
 | **Imports** | Check `package.json` and instruction files for allowed packages. | Verify before adding dependencies |
 | **State** | Follow frontend instructions for state management patterns and store usage. | See frontend instructions |
 | **Queries** | Follow backend instructions for data access patterns and repository/ORM usage. | See backend instructions |

--- a/rnd/templates/e2e-result.md
+++ b/rnd/templates/e2e-result.md
@@ -404,7 +404,7 @@ Test artifacts (failed tests only):
 
 ### E. Artifact Retention Policy
 
-Per `rnd/instructions/e2e-testing.instructions.md`:
+Per the E2E testing guidance in the applicable `AGENTS.md` / `CLAUDE.md`:
 - **Screenshots:** Saved only for failed tests
 - **Videos:** Saved only for failed tests (retain-on-failure)
 - **Traces:** Saved only on first retry

--- a/rnd/templates/tech_spec.md
+++ b/rnd/templates/tech_spec.md
@@ -97,7 +97,7 @@ interface ExampleEntity {
 
 #### 3.3.2 State Management
 
-Describe store changes or new stores (follow `rnd/instructions/frontend.instructions.md`).
+Describe store changes or new stores (follow the frontend guidance in the applicable `AGENTS.md` / `CLAUDE.md`).
 
 - **Store:** `use<Feature>Store` (file path: `src/frontend/stores/use<Feature>Store`)
   - State: `items`, `loading`, `error`


### PR DESCRIPTION
## Summary

- Replace stale `rnd/instructions/*.instructions.md` references in RnD skills and templates with scoped `AGENTS.md` / `CLAUDE.md` guidance.
- Update build-plan and tech-spec templates to point agents at repo/app/module-level instruction files.
- Keep the change limited to markdown process artifacts under `rnd/skills` and `rnd/templates`.

## Validation

- `rg -n "rnd/instructions|\.instructions\.md|instructions/|files files|applicable applicable|path-specific applicable" rnd/skills rnd/agents rnd/templates --glob '*.md'`
- `git diff --cached --check`