### PR TITLE
feat(cli): enhance worktree command with branch arg, --no-command, and --list

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,10 @@ Examples:
 
 ```bash
 r3nd worktree
+r3nd worktree --list
+r3nd worktree auth-investigation
 r3nd worktree --branch auth-investigation
+r3nd worktree auth-investigation --no-command
 r3nd worktree clean
 ```
 
@@ -371,7 +374,10 @@ The worktree flow can:
 - create repo-scoped git worktrees
 - open an existing worktree
 - clean up r3nd-managed clean worktrees
+- list all worktrees in `git worktree list` format
 - copy vendor directories like `.claude`, `.codex`, `.github`, and `.cursor` into the new worktree when present
+- accept branch names via `r3nd worktree [branch]` or `--branch`
+- skip the open command with `--no-command` and print the created/selected worktree path instead
 
 What gets copied into a new worktree and what command gets run afterward are both configurable in `r3nd.yaml`.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -127,9 +127,12 @@ Commands:
 
 - `worktree`: Open an existing repo worktree or create a new repo-scoped git worktree under `~/.r3nd/worktrees/`.
   - Options:
+    - `[branch]`: Positional branch name for the new worktree.
     - `-br, --branch <name>`: Use a specific branch name instead of generating one automatically.
+    - `-l, --list`: Print all worktrees for the current repository (same format as `git worktree list`).
+    - `-nc, --no-command`: Skip running `worktree-open-command` and print the worktree directory path.
   - Behavior:
-    - Without `--branch`, shows all git worktrees for the current repository and lets you choose one to open with the configured `worktree-open-command`.
+    - Without a branch argument, shows all git worktrees for the current repository and lets you choose one to open with the configured `worktree-open-command`.
     - Appends a `New worktree` option to that list.
     - Choosing `New worktree` prompts for a branch name; leaving it empty uses an automatic faker-based branch name.
     - Copies every directory named as your configured `spec-dir-name`.
@@ -140,7 +143,10 @@ Commands:
 
     ```bash
     r3nd worktree
+    r3nd worktree --list
+    r3nd worktree auth-investigation
     r3nd worktree --branch auth-investigation
+    r3nd worktree auth-investigation --no-command
     ```
 
 - `worktree clean`: Delete clean r3nd-managed worktrees for the current repository.

--- a/cli/src/commands/worktree.js
+++ b/cli/src/commands/worktree.js
@@ -1,20 +1,33 @@
-const { runWorktree, runWorktreeCreate, runWorktreeClean } = require('../lib/worktreeService');
+const { runWorktree, runWorktreeCreate, runWorktreeList, runWorktreeClean } = require('../lib/worktreeService');
 
 function register(program) {
   const worktree = program
-    .command('worktree')
+    .command('worktree [branch]')
     .description('Create and clean repo-scoped git worktrees under ~/.r3nd/worktrees');
 
   worktree
+    .option('-l, --list', 'List all worktrees for the current repository')
+    .option('-nc, --no-command', 'Return the worktree directory and skip the open command')
     .option('-br, --branch <name>', 'Branch name for the new worktree')
-    .action(async (options) => {
+    .action(async (branchArg, options) => {
       try {
-        if (options.branch) {
-          await runWorktreeCreate({ branch: options.branch });
+        if (options.list) {
+          const output = await runWorktreeList();
+          if (output) {
+            console.log(output);
+          }
           return;
         }
 
-        await runWorktree();
+        const branch = options.branch || branchArg;
+        const result = branch
+          ? await runWorktreeCreate({ branch, noCommand: options.noCommand })
+          : await runWorktree({ noCommand: options.noCommand });
+
+        if (options.noCommand && result && result.path) {
+          console.log(result.path);
+          return;
+        }
       } catch (err) {
         console.error('Worktree command failed:', err && err.message ? err.message : err);
         process.exit(1);

--- a/cli/src/lib/worktreeService.js
+++ b/cli/src/lib/worktreeService.js
@@ -379,6 +379,7 @@ async function getRepoContext(cwd, deps = {}) {
 async function runWorktreeCreate(opts = {}, deps = {}) {
   const cwd = opts.cwd || process.cwd();
   const nonInteractive = !!opts.nonInteractive;
+  const noCommand = !!opts.noCommand;
   const configManager = deps.configManager || new ConfigManager(cwd);
   const configured = await ensureWorktreeConfig(configManager, deps, { nonInteractive });
   const copyPatterns = await configManager.getWorktreeCopyFiles();
@@ -405,10 +406,12 @@ async function runWorktreeCreate(opts = {}, deps = {}) {
   const specDirName = await configManager.getSpecDirName();
   const copied = await copyManagedFiles(repoRoot, branchPlan.targetPath, specDirName, copyPatterns);
 
-  try {
-    await openWorktree(branchPlan.targetPath, openCommand, deps);
-  } catch (err) {
-    logger.warn(`Worktree created at ${branchPlan.targetPath}, but failed to launch the open command: ${err.message}`);
+  if (!noCommand) {
+    try {
+      await openWorktree(branchPlan.targetPath, openCommand, deps);
+    } catch (err) {
+      logger.warn(`Worktree created at ${branchPlan.targetPath}, but failed to launch the open command: ${err.message}`);
+    }
   }
 
   logger.info(`✓ Created worktree ${branchPlan.branchName} at ${branchPlan.targetPath}`);
@@ -426,6 +429,7 @@ async function runWorktreeCreate(opts = {}, deps = {}) {
 async function runWorktree(opts = {}, deps = {}) {
   const cwd = opts.cwd || process.cwd();
   const nonInteractive = !!opts.nonInteractive;
+  const noCommand = !!opts.noCommand;
 
   if (opts.branch || nonInteractive) {
     return runWorktreeCreate(opts, deps);
@@ -450,12 +454,21 @@ async function runWorktree(opts = {}, deps = {}) {
     }, deps);
   }
 
-  await openWorktree(selectedPath, openCommand, deps);
-  logger.info(`✓ Opened worktree ${selectedPath}`);
+  if (!noCommand) {
+    await openWorktree(selectedPath, openCommand, deps);
+    logger.info(`✓ Opened worktree ${selectedPath}`);
+  }
 
   return {
     path: selectedPath
   };
+}
+
+async function runWorktreeList(opts = {}, deps = {}) {
+  const cwd = opts.cwd || process.cwd();
+  const { repoRoot } = await getRepoContext(cwd, deps);
+  const listResult = await runGit(repoRoot, ['worktree', 'list'], deps);
+  return listResult.stdout.trimEnd();
 }
 
 async function runWorktreeClean(opts = {}, deps = {}) {
@@ -511,6 +524,7 @@ module.exports = {
   getRepoScopeName,
   WORKTREE_VENDOR_DIRS,
   runWorktree,
+  runWorktreeList,
   runWorktreeCreate,
   runWorktreeClean
 };

--- a/cli/src/lib/worktreeService.spec.js
+++ b/cli/src/lib/worktreeService.spec.js
@@ -15,6 +15,7 @@ jest.mock('./ui/prompts', () => ({
 const { ConfigManager } = require('./config/configManager');
 const {
   runWorktree,
+  runWorktreeList,
   runWorktreeCreate,
   runWorktreeClean,
   getRepoScopeName,
@@ -120,6 +121,14 @@ describe('worktreeService', () => {
     expect(deps.spawnRunner).toHaveBeenCalled();
   });
 
+  it('creates a worktree without launching the open command when noCommand is true', async () => {
+    const result = await runWorktreeCreate({ cwd: repoDir, branch: 'no-open-branch', noCommand: true }, deps);
+
+    expect(result.path).toBe(path.join(worktreeScopeRoot, 'no-open-branch'));
+    await expect(fs.access(result.path)).resolves.toBeUndefined();
+    expect(deps.spawnRunner).not.toHaveBeenCalled();
+  });
+
   it('rejects creating a second worktree for a branch already checked out elsewhere', async () => {
     await runWorktreeCreate({ cwd: repoDir, branch: 'dupe-branch' }, deps);
 
@@ -162,6 +171,18 @@ describe('worktreeService', () => {
       cwd: existingWorktree.path,
       stdio: 'inherit'
     }));
+  });
+
+  it('returns selected existing worktree path without opening when noCommand is true', async () => {
+    const existingWorktree = await runWorktreeCreate({ cwd: repoDir, branch: 'existing-branch-no-open' }, deps);
+
+    deps.spawnRunner.mockClear();
+    deps.askWorktreeSelection.mockResolvedValueOnce(existingWorktree.path);
+
+    const result = await runWorktree({ cwd: repoDir, noCommand: true }, deps);
+
+    expect(result).toEqual({ path: existingWorktree.path });
+    expect(deps.spawnRunner).not.toHaveBeenCalled();
   });
 
   it('creates a new worktree from the chooser and auto-generates the branch name when left blank', async () => {
@@ -215,6 +236,16 @@ describe('worktreeService', () => {
       '{worktreeDir}',
       '--reuse-window'
     ]);
+  });
+
+  it('returns all worktrees in git worktree list format', async () => {
+    const linkedWorktree = await runWorktreeCreate({ cwd: repoDir, branch: 'list-branch', noCommand: true }, deps);
+    const output = await runWorktreeList({ cwd: repoDir }, deps);
+
+    expect(output).toContain(repoDir);
+    expect(output).toContain(linkedWorktree.path);
+    expect(output).toContain('[develop]');
+    expect(output).toContain('[list-branch]');
   });
 
   it('creates a new worktree under the correct scope when called from inside a linked worktree', async () => {


### PR DESCRIPTION
## Summary
- add positional branch argument support to `r3nd worktree [branch]`
- add `--no-command` to skip open command and print the worktree path
- add `--list` to print all worktrees in `git worktree list` format
- add service tests for `noCommand` and list behavior
- update both `README.md` and `cli/README.md`

## Validation
- npx jest --runInBand src/lib/worktreeService.spec.js
- npx jest --runInBand src/lib/worktreeService.spec.js src/index.spec.js