### PR TITLE
fix(worktree): --no-command correctly skips IDE open and prints path

### DIFF
--- a/cli/src/commands/worktree.js
+++ b/cli/src/commands/worktree.js
@@ -20,11 +20,13 @@ function register(program) {
         }
 
         const branch = options.branch || branchArg;
+        // Commander sets options.command=false for --no-command (negation flag), not options.noCommand
+        const noCommand = !options.command;
         const result = branch
-          ? await runWorktreeCreate({ branch, noCommand: options.noCommand })
-          : await runWorktree({ noCommand: options.noCommand });
+          ? await runWorktreeCreate({ branch, noCommand })
+          : await runWorktree({ noCommand });
 
-        if (options.noCommand && result && result.path) {
+        if (noCommand && result && result.path) {
           console.log(result.path);
           return;
         }


### PR DESCRIPTION
## Summary

- Fixes `--no-command` / `-nc` flag: Commander.js sets `options.command = false` for `--no-command` negation options, but the handler was reading `options.noCommand` (always `undefined`), so the flag had no effect — the IDE open always ran and the path was never printed to stdout
- The fix reads `!options.command` and passes it as `noCommand` to `runWorktreeCreate` / `runWorktree`

## Root cause

Commander's `--no-<name>` pattern sets the property named `<name>` to `false`, not `no<Name>` to `true`. With `-nc, --no-command` defined, `options.command` defaults to `true` and becomes `false` when the flag is passed. The old code checked `options.noCommand` which was never set.

## Test plan

- [ ] `r3nd worktree -br my-branch --no-command` — prints the worktree path to stdout and does **not** attempt to open an IDE
- [ ] `r3nd worktree -br my-branch` (without flag) — opens the configured IDE as before
- [ ] `r3nd worktree -l` — lists worktrees unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)