### PR TITLE
Add MVP workflow overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ r3nd init
 
 # Full setup for new projects
 # Current overlay options include:
-# angular, fast-api, nestjs, prototyping, ruby-on-rails, vue
+# angular, fast-api, mvp, nestjs, prototyping, ruby-on-rails, vue
 r3nd scaffold
 ```
 

--- a/cli/src/lib/overlays/mindsetOverlays.spec.js
+++ b/cli/src/lib/overlays/mindsetOverlays.spec.js
@@ -1,0 +1,88 @@
+const fs = require('fs');
+const path = require('path');
+
+const { parseTemplate } = require('../templateResolver');
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const EXPECTED_OVERRIDES = [
+  'skills/bugfix/SKILL.md',
+  'skills/create-build-plan/SKILL.md',
+  'skills/create-tech-spec/SKILL.md',
+  'skills/create-test-cases/SKILL.md',
+  'skills/implement-build-plan/SKILL.md',
+  'skills/implement-feature/SKILL.md',
+  'skills/run-e2e-tests/SKILL.md',
+  'skills/run-manual-qa-tests/SKILL.md',
+  'templates/build_plan.md',
+  'templates/tech_spec.md',
+  'templates/test_cases.md'
+];
+
+function resolvePlaceholderPath(overlayRoot, placeholder) {
+  const basePath = path.join(REPO_ROOT, placeholder);
+  if (fs.existsSync(basePath)) {
+    return basePath;
+  }
+
+  if (placeholder.startsWith('rnd/')) {
+    const overlayPath = path.join(overlayRoot, placeholder.slice('rnd/'.length));
+    if (fs.existsSync(overlayPath)) {
+      return overlayPath;
+    }
+  }
+
+  return null;
+}
+
+describe.each([
+  ['prototyping', 'prototyping'],
+  ['mvp', 'mvp']
+])('%s mindset overlay', (overlayName, sharedPolicyName) => {
+  const overlayRoot = path.join(REPO_ROOT, 'overlays', overlayName);
+  const expectedFiles = [
+    `agents/shared/${sharedPolicyName}.md`,
+    ...EXPECTED_OVERRIDES
+  ];
+
+  it('provides the complete compact-workflow override set', () => {
+    for (const relativePath of expectedFiles) {
+      expect(fs.existsSync(path.join(overlayRoot, relativePath))).toBe(true);
+    }
+  });
+
+  it('has no unresolved template references', () => {
+    for (const relativePath of expectedFiles) {
+      const filePath = path.join(overlayRoot, relativePath);
+      const content = fs.readFileSync(filePath, 'utf-8');
+
+      for (const placeholder of parseTemplate(content)) {
+        expect(resolvePlaceholderPath(overlayRoot, placeholder)).not.toBeNull();
+      }
+    }
+  });
+});
+
+describe('mvp production baseline', () => {
+  it('keeps every minimum production concern explicit in the shared policy and tech spec', () => {
+    const policy = fs.readFileSync(
+      path.join(REPO_ROOT, 'overlays/mvp/agents/shared/mvp.md'),
+      'utf-8'
+    );
+    const techSpec = fs.readFileSync(
+      path.join(REPO_ROOT, 'overlays/mvp/templates/tech_spec.md'),
+      'utf-8'
+    );
+
+    for (const [policyConcern, specConcern] of [
+      ['CI', 'CI'],
+      ['Runtime', 'Runtime and config'],
+      ['Security', 'Security'],
+      ['Compatibility and data', 'Compatibility and data'],
+      ['Operability', 'Operability'],
+      ['Identity and tenancy', 'Identity and tenancy']
+    ]) {
+      expect(policy).toContain(`**${policyConcern}:**`);
+      expect(techSpec).toContain(`| ${specConcern} |`);
+    }
+  });
+});

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -121,12 +121,18 @@ Current overlay examples referenced by the docs and CLI flow:
 
 - `angular`
 - `fast-api`
+- `mvp`
 - `nestjs`
 - `prototyping`
 - `ruby-on-rails`
 - `vue`
 
-Select `prototyping` after any stack overlays so its workflow, template, and testing overrides take precedence. It starts feature work with a short tech spec, uses compact build plans, requires focused unit tests, excludes integration tests, and asks whether post-implementation QA should be AI-run manual QA, reusable E2E test code, both, or neither. Repeated fix attempts stop after two cycles to ask for help.
+Select a mindset overlay after any stack overlays so its workflow, template, and testing overrides take precedence:
+
+- `prototyping` starts with a short tech spec, uses compact build plans, requires focused unit tests, excludes integration tests, and prefers the smallest demonstrable runtime.
+- `mvp` keeps that focused workflow while requiring the applicable minimum production baseline: deterministic CI, a production container/runtime, explicit security and identity/tenant decisions, compatibility and migration handling, and just-enough logs, health signals, and metrics.
+
+Treat `prototyping` and `mvp` as alternatives. If both are configured, the one selected later wins because overlays are applied in order. Both ask whether post-implementation QA should be AI-run manual QA, reusable E2E test code, both, or neither, and both stop after two unsuccessful attempts at the same loop to ask for help.
 
 ## Configure The Repository
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -19,6 +19,12 @@ The important distinction is not speed. It is how much artifact structure and ho
 
 When `prototyping` is selected after the stack overlays, full control starts with a brief tech spec rather than a product spec, semi-control uses the streamlined `implement-feature` override, and bugfix uses the same minimal-fix policy. Full control remains a user-driven sequence rather than gaining a coordinator skill. After full-control or semi-control implementation, the workflow asks whether to run AI manual QA, write reusable E2E test code, do both, or do neither; test-case artifacts are created only for reusable E2E. Prototyping omits integration tests, prefers minimal containerized infrastructure, and stops after two unsuccessful attempts at the same loop to ask the user for help.
 
+### MVP Overlay
+
+Select `mvp` after the stack overlays when the first release must stay prototype-fast but run as a real production system. It uses the same brief tech-spec, compact-plan, and user-selected QA shape as `prototyping`, but raises the completion bar to the smallest applicable production baseline: deterministic CI, a production Docker/runtime path, explicit configuration and secret handling, security and identity/tenant decisions, compatibility and migration safety, health signals, useful structured logs, and only metrics tied to a concrete operational question.
+
+The MVP overlay does not require every concern to create code. Specs and plans mark a concern `Not applicable` with a reason when it is irrelevant, reuse existing boilerplate before adding anything, and add focused boundary/contract coverage only for risks that unit tests cannot credibly prove. Treat `mvp` and `prototyping` as alternative mindset overlays; if both are selected, the later overlay takes precedence.
+
 ## 1. Full Control Workflow
 
 Use this when the change needs explicit handoffs and human review between stages.

--- a/overlays/mvp/agents/shared/mvp.md
+++ b/overlays/mvp/agents/shared/mvp.md
@@ -1,0 +1,51 @@
+# MVP Mode
+
+Use this policy for every workflow in this overlay. Its goal is the smallest production-shaped system that can deliver and operate real user value safely.
+
+## Priorities
+
+1. Deliver a focused vertical slice that users can run and the team can deploy.
+2. Preserve correctness, data, access boundaries, and existing external contracts.
+3. Add only the delivery and operational baseline needed to support this slice in production.
+4. Keep decisions reversible and defer scale, platform machinery, and polish until evidence requires them.
+
+## Engineering Rules
+
+- Prefer the existing stack, its standard tooling, and the repository's simplest established patterns.
+- Prefer one deployable, one datastore, synchronous calls, and framework-native features when they are enough.
+- Do not introduce Kubernetes, Argo, Kafka, a service mesh, a monorepo orchestrator, or similar platform machinery unless requested or required by a demonstrated constraint.
+- Keep modules small and define explicit contracts at real boundaries: public APIs, persistence, events, files, external services, authentication, and tenant ownership.
+- Use additive changes for contracts that may already have consumers. When a breaking API, schema, event, or configuration change is necessary, include the smallest migration or compatibility window and a safe rollback path.
+- Make reversible, low-risk decisions directly and record the assumption briefly. Ask when a missing decision can change behavior, data ownership, a public contract, security posture, tenancy, or technology.
+
+## Minimum Production Baseline
+
+Apply each concern only where it is relevant. Record `Not applicable` with one short reason instead of generating unused boilerplate.
+
+- **CI:** Reuse the current pipeline. If none exists, add one minimal workflow that installs from the lockfile and runs the repository's applicable lint, type, unit/boundary-test, build, and container-build checks. Keep required checks deterministic and free of production secrets.
+- **Runtime:** Provide or preserve a production Dockerfile for a deployed service. Prefer a small build context, locked dependencies, a non-root runtime where the stack supports it, explicit configuration, graceful shutdown, and health/readiness behavior. Add Compose only for dependencies needed to run or verify the system locally.
+- **Security:** Validate untrusted input at the boundary, enforce authentication and authorization where protected data or actions exist, preserve tenant isolation, keep secrets out of code/images/logs, and avoid exposing sensitive error details. Use the repository's existing security controls before adding new ones.
+- **Compatibility and data:** Identify existing consumers and stored data before changing public contracts or schemas. Prefer additive migrations and tolerant readers. Use expand/migrate/contract only when independent deployments or zero-downtime operation make it necessary.
+- **Operability:** Use the existing logging and telemetry stack. Add structured logs for important lifecycle and failure events, propagate a request/correlation id in request-based services when practical, and expose health/readiness signals. Add metrics only for a concrete operational question; do not create a telemetry platform for an MVP.
+- **Identity and tenancy:** Decide explicitly whether the slice is public, authenticated, or tenant-scoped. Reuse existing identity and tenant context. Never trust a client-supplied tenant id without authorization against the authenticated principal.
+
+## Testing Rules
+
+- Reuse the established test frameworks and commands; do not add a second tool for preference.
+- Add focused unit tests for new behavior through public interfaces, including the most important failure or authorization case.
+- Add one focused boundary, contract, or integration test only when a production risk such as persistence, migrations, auth/tenant isolation, an external dependency, or compatibility cannot be proven credibly with unit tests. Do not build a broad integration suite by default.
+- Ensure required automated checks are executed by CI. Keep slow or environment-heavy suites out of the required path unless they are stable and protect a critical flow.
+- At the owning full-control or `implement-feature` boundary, ask whether the user wants AI-run manual QA, reusable E2E test code, both, or neither. Ask once; delegated implementation and QA skills must not repeat the choice.
+- When reusable E2E is selected, cover the primary flow and only directly relevant security, tenant, or compatibility edges.
+- Prefer targeted local checks plus the same commands CI will run. Do not silently expand scope to unrelated repository failures.
+
+## Retry And Help Rules
+
+- Automatically fix issues that block the requested behavior, required checks, production runtime, or selected QA path.
+- Treat a security, tenant-isolation, data-loss, or required-compatibility gap in changed code as blocking.
+- For unrelated failures, optional hardening, cleanup, platform improvements, or speculative scale work, stop and ask whether to expand scope.
+- Make at most two attempts at the same failing command, hypothesis, setup path, or fix loop. If the second attempt fails, ask for help with both attempts, the smallest useful error excerpt, and the exact decision or information needed.
+
+## Completion Standard
+
+The work is complete when the requested slice works, focused automated checks pass, required CI coverage is present, the production runtime builds and starts when applicable, and the spec's relevant security, compatibility, identity/tenancy, and operability decisions are implemented. Complete the user-selected QA paths and report intentionally deferred production work without turning it into hidden scope.

--- a/overlays/mvp/skills/bugfix/SKILL.md
+++ b/overlays/mvp/skills/bugfix/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: bugfix
+description: Reproduce and minimally fix an MVP defect while protecting production contracts and safety boundaries.
+---
+
+# Bugfix — MVP
+
+Restore the requested behavior with the smallest production-safe change and focused regression evidence.
+
+{{rnd/agents/shared/mvp.md}}
+{{rnd/agents/shared/command-hygiene.md}}
+
+## Workflow
+
+### 1. Reproduce
+
+1. Turn the report into one concise repro: precondition, action, expected result, and observed result.
+2. Use the shortest local path that represents the deployed boundary. Prefer the production container/runtime when the defect depends on packaging or configuration.
+3. Make at most one focused setup or methodology correction. If the second attempt still cannot reproduce, ask for the missing data or environment detail.
+
+### 2. Diagnose
+
+1. Inspect the failing path, nearby tests, CI/runtime behavior, and relevant scoped instructions.
+2. Read matching specs or plans when they clarify intent. Inspect git history only when current code and tests do not.
+3. Identify affected public consumers, stored data, authorization or tenant boundaries, and operational signals.
+4. Find the narrowest change that restores intended behavior without weakening security, losing data, or breaking an existing contract.
+
+### 3. Plan
+
+State the cause, intended change, compatibility/migration implications, files affected, and verification in a few bullets. Create a durable build plan only when the CLI requires it or the fix needs a multi-step handoff.
+
+If the request already authorized a fix, proceed unless the diagnosis reveals a material behavior, data ownership, public-contract, security/tenancy, or technology choice.
+
+### 4. Implement
+
+1. Apply the smallest clear change in the existing architecture.
+2. Preserve public and stored-data compatibility or implement the smallest explicit migration/backout path.
+3. Keep authorization, tenant ownership, secret handling, and safe errors at least as strong as before.
+4. Add a focused unit regression test and one boundary/contract regression only when the defect crossed a real production boundary.
+5. Ensure new regression commands are already covered by CI; update the narrow CI path if they are not.
+6. Avoid unrelated cleanup, dependency upgrades, new infrastructure, or observability work.
+
+### 5. Verify
+
+1. Re-run the original repro against the applicable production-like runtime.
+2. Run focused regression checks and the relevant CI-equivalent build/image command.
+3. Verify any affected compatibility, data, authorization, tenant-isolation, health, or logging behavior.
+4. Automatically fix only blocking issues. Use at most two repair-and-verification cycles for the same failure, then ask for help with evidence.
+5. Ask before expanding into non-blocking warnings or adjacent defects.
+
+## Output
+
+Report the cause, minimal fix, compatibility/security impact, commands and results, and intentional follow-up debt. Do not add a broad readiness review or documentation bundle unless requested.

--- a/overlays/mvp/skills/create-build-plan/SKILL.md
+++ b/overlays/mvp/skills/create-build-plan/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: create-build-plan
+description: Turn an MVP tech-spec task into the shortest production-aware executable plan.
+---
+
+# Create Build Plan — MVP
+
+Create a compact plan that delivers one compatible, deployable slice without turning production readiness into a platform project.
+
+{{rnd/agents/shared/mvp.md}}
+{{rnd/agents/shared/command-hygiene.md}}
+
+## Inputs
+
+- A tech spec under `rnd/tech_specs/`, or a concrete bug/problem statement
+- Relevant code, scoped instructions, CI, Docker/runtime, and operational patterns
+- `rnd/templates/build_plan.md`
+
+## Outputs
+
+- For a tech spec, one `rnd/build_plans/<feature-id>-T<n>-build-plan.md` per task that genuinely needs separate execution
+- For a concrete bounded problem, one short build plan
+
+Do not split work merely to create more plans. A single vertical slice should normally have one plan.
+
+## Required Content
+
+- Outcome, scope, dependencies, and contracts consumed/exposed
+- Non-obvious algorithm, state, schema, migration, release, or rollback rules
+- Applicable CI, runtime/config, security/auth/tenancy, compatibility, and operability work
+- A short ordered checklist naming likely files or components
+- Focused unit checks, a boundary/contract test only for a real production risk, CI-equivalent commands, and a production-runtime smoke check
+- The primary flow and directly relevant security, tenant, or compatibility edge for optional QA
+- Blocking questions only
+
+## Workflow
+
+1. Read the source and MVP build-plan template.
+2. Inspect only the affected code plus established patterns for the applicable production concerns.
+3. Preserve task ids and dependency order from the tech spec.
+4. Name public contracts, data transitions, authorization/ownership rules, and operational signals precisely enough for separate tasks to remain compatible.
+5. Prefer an additive contract or migration. Include expand/migrate/contract only when independent deploys or uptime constraints require it.
+6. Reuse existing CI and runtime files. Add the smallest missing check or container change that makes this task safely deployable.
+7. Plan focused tests. Do not create a broad integration suite or duplicate behavior already proven cheaply at a lower level.
+8. Mark irrelevant baseline concerns `Not applicable — <reason>` and write the plan without estimates, generic guardrails, or repeated spec prose.
+
+Ask when ambiguity changes behavior, data ownership, a public contract, security, tenancy, or technology. Otherwise choose the simplest reversible implementation and note it briefly.

--- a/overlays/mvp/skills/create-tech-spec/SKILL.md
+++ b/overlays/mvp/skills/create-tech-spec/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: create-tech-spec
+description: Design the smallest production-shaped vertical slice for an MVP.
+---
+
+# Create Tech Spec — MVP
+
+Create a concise technical specification that is simple enough to execute quickly and explicit enough to deploy responsibly.
+
+{{rnd/agents/shared/mvp.md}}
+{{rnd/agents/shared/command-hygiene.md}}
+
+## Inputs
+
+- Direct user requirements, issue text, or another supplied description
+- Existing repository code and the nearest applicable `AGENTS.md` / `CLAUDE.md`
+- Existing CI, container, configuration, identity, tenancy, logging, metrics, and migration patterns
+- `rnd/templates/tech_spec.md`
+- An existing product spec only when already supplied; it is supporting input, never a prerequisite
+
+## Output
+
+Write one file under `rnd/tech_specs/`, following the repository's naming convention or `YYYY-MM-DD-<feature-id>/YYYY-MM-DD-tech-spec-<feature-id>.md` when none exists.
+
+The tech spec is the first required artifact. Do not create or require a product spec merely for process completeness.
+
+## Required Content
+
+- Brief functional requirements, constraints, out-of-scope items, and reversible assumptions
+- Relevant existing application and production-baseline patterns
+- One component diagram and explicit contracts at real boundaries
+- The minimum CI, production runtime/configuration, security, identity/tenancy, compatibility/data, and operability decisions
+- Non-obvious state, migration, failure, release, or rollback behavior
+- A small task breakdown that assigns applicable production-baseline work to the vertical slice
+- Focused unit intent, one boundary/contract test only where risk warrants it, CI checks, runtime smoke, and optional QA candidates
+- Only questions that block a correct or safe design
+
+## Workflow
+
+1. Read the request and compact tech-spec template.
+2. Inspect the affected code and one useful existing pattern for each applicable concern. Do not survey the whole platform.
+3. Identify deployed consumers, stored data, trust boundaries, and whether the slice is public, authenticated, or tenant-scoped.
+4. Reuse the repository's CI, Docker, configuration, security, migration, logging, and telemetry conventions. Add a missing baseline only when this slice needs it to operate safely.
+5. Choose the simplest deployable design and record `Not applicable — <reason>` for irrelevant baseline concerns.
+6. Prefer additive contracts and migrations. Ask before an avoidable breaking change, unclear data ownership, security decision, tenancy model, or material technology addition.
+7. Create tasks only where sequencing, ownership, or contracts benefit from separation.
+8. Validate that the tasks collectively deliver the behavior and production baseline, then write the file.
+
+## Exclusions
+
+- No exhaustive architecture survey, compliance program, generic threat model, SRE platform, speculative scaling plan, or broad observability rollout
+- No Kubernetes, service mesh, queue, cache, or microservice split without a demonstrated requirement
+- No implementation code or extra artifact created only to satisfy process
+- No backwards-compatibility layer for a new private interface with no consumers
+
+If research or clarification repeats without progress, follow the two-attempt stop rule and ask the user.

--- a/overlays/mvp/skills/create-test-cases/SKILL.md
+++ b/overlays/mvp/skills/create-test-cases/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: create-test-cases
+description: Create a small MVP E2E set for the primary flow and critical production boundaries.
+---
+
+# Create Test Cases — MVP
+
+Describe only the end-to-end behavior needed to prove the MVP's value and its directly relevant production boundaries.
+
+{{rnd/agents/shared/mvp.md}}
+{{rnd/agents/shared/command-hygiene.md}}
+
+Run this skill only when the user selects **reusable E2E test code** or invokes it directly. AI-run manual QA alone does not require a test-case document.
+
+## Inputs
+
+- Relevant tech spec and build plans
+- Implemented code and production-baseline decisions when available
+- `rnd/templates/test_cases.md`
+
+## Output
+
+Write one concise file under `rnd/test_cases/` using the template. Usually create 1–8 cases; exceed that only when the user explicitly needs broader coverage.
+
+## Selection Rules
+
+1. Always include the primary happy path that demonstrates user value through the deployed boundary.
+2. Add only directly relevant high-risk cases: denied access, cross-tenant isolation, a legacy contract, migration behavior, safe dependency failure, or recovery/readiness.
+3. Do not repeat unit or boundary tests unless the full-system behavior carries a distinct risk.
+4. Prefer observable outcomes and safe external errors over internal calls or implementation details.
+5. Keep setup minimal and production-like. Reuse existing accounts, tenant fixtures, selectors, images, and Compose services.
+6. Map every case to one requirement or production-baseline decision without copying source prose.
+7. If expected security, tenancy, data, or compatibility behavior is ambiguous, ask instead of inventing it.
+
+Do not add exhaustive permission matrices, browser matrices, load tests, or speculative failure permutations by default.

--- a/overlays/mvp/skills/implement-build-plan/SKILL.md
+++ b/overlays/mvp/skills/implement-build-plan/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: implement-build-plan
+description: Implement an MVP plan as a production-shaped vertical slice with focused verification.
+---
+
+# Implement Build Plan — MVP
+
+Deliver the plan quickly while preserving the minimum production baseline selected in the tech spec.
+
+{{rnd/agents/shared/mvp.md}}
+{{rnd/agents/shared/command-hygiene.md}}
+
+## Inputs
+
+- The selected file under `rnd/build_plans/`
+- Relevant code, tests, manifests, CI, runtime files, and scoped `AGENTS.md` / `CLAUDE.md`
+- Existing repository patterns for the touched area
+
+## Outputs
+
+- Working code and focused automated tests
+- Applicable CI, production runtime/config, security, compatibility/migration, and operability changes
+- Optional reusable E2E code and/or manual-QA result when selected at the final handoff
+- Completed checkboxes and a brief plan clarification only when implementation materially differs
+
+## Workflow
+
+1. Read the plan and inspect the affected code plus the referenced production patterns.
+2. Confirm predecessor contracts and required configuration exist. Ask immediately if a missing contract, security/tenant decision, or migration choice blocks safe work.
+3. Implement the smallest vertical slice that satisfies the plan. Avoid speculative abstraction and infrastructure.
+4. Preserve existing public behavior and stored data. Use additive changes or the plan's migration/compatibility path.
+5. Validate inputs and authorization at real boundaries, enforce tenant ownership where applicable, and keep secrets and sensitive values out of source, images, errors, and logs.
+6. Add only useful structured lifecycle/failure logs, health/readiness behavior, correlation, and metrics named by the plan.
+7. Reuse or add the minimal production Dockerfile/configuration and CI checks assigned to the task.
+8. Add focused unit tests and the planned boundary/contract test when applicable.
+9. Run the smallest relevant checks, then the CI-equivalent lint/type/test/build/image commands.
+10. Build and start the production runtime in detached mode when applicable, verify health/readiness, and stop only services started by this workflow.
+11. Mark completed plan items and report exact commands and results.
+
+## Full-Control QA Handoff
+
+Full control is user-driven. Do not create test cases or E2E files automatically.
+
+When this plan completes the final approved implementation plan, ask exactly:
+
+`Which post-implementation QA do you want: AI-run manual QA, reusable E2E test code, both, or neither?`
+
+- **AI-run manual QA:** Use `rnd/skills/run-manual-qa-tests/SKILL.md` from the acceptance criteria. Do not create a test-case document.
+- **Reusable E2E test code:** Use `rnd/skills/create-test-cases/SKILL.md`, then `rnd/skills/run-e2e-tests/SKILL.md`.
+- **Both:** Complete both paths.
+- **Neither:** Skip both and clearly report the automated verification that was completed.
+
+If this is not the final plan, defer the question. When called by `implement-feature`, defer it because that coordinator owns the single feature-level choice.
+
+## Failure Handling
+
+- Fix blocking implementation, required-check, production-runtime, security/tenancy, data/compatibility, or selected-QA failures.
+- Use at most two repair-and-verification cycles for the same failure, then ask for help with evidence.
+- Ask before expanding into unrelated failures, optional hardening, cleanup, or platform improvements.
+
+## Done
+
+The plan is done when behavior and applicable production-baseline items work, required checks pass in their CI path, the production runtime smokes successfully when applicable, and selected QA paths pass. Report intentional deferrals plainly.

--- a/overlays/mvp/skills/implement-feature/SKILL.md
+++ b/overlays/mvp/skills/implement-feature/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: implement-feature
+description: Run an approved MVP tech spec through planning, production-aware implementation, and selected QA.
+---
+
+# Implement Feature — MVP Semi-Control
+
+Coordinate an approved tech spec into the smallest safely deployable feature without production-process ceremony.
+
+{{rnd/agents/shared/mvp.md}}
+{{rnd/agents/shared/command-hygiene.md}}
+
+## Input
+
+- An approved tech-spec file or feature directory under `rnd/tech_specs/`
+- Relevant code, scoped instructions, CI, runtime, and operational files
+- Existing build plans and test cases when present
+
+Invoking this skill with an approved tech spec authorizes implementation. Do not add another approval gate unless a missing choice changes behavior, data ownership, a public contract, security, tenancy, or technology.
+
+## Minimal Outputs
+
+- Compact build plans under `rnd/build_plans/` when missing
+- Working code and focused automated tests
+- Applicable CI, production runtime, security, compatibility/migration, and operability changes
+- Optional concise cases and reusable E2E code and/or a manual-QA result when selected
+- One concise `run-summary.md` under `rnd/agent_runs/<feature-id>/` only when the invoking tool requires it
+
+Do not create coordination bundles, broad readiness checklists, generic platform artifacts, retros, or QA artifacts that the selected workflow does not need.
+
+## Workflow
+
+### 1. Resolve
+
+1. Read the tech spec and inspect the affected code and production patterns.
+2. Identify tasks, dependencies, public/data boundaries, trust boundaries, and the slice's identity/tenant context.
+3. Ask immediately if a missing decision changes behavior or safety. Otherwise use the simplest reversible assumption.
+
+### 2. Assure Plans
+
+1. Reuse valid existing plans.
+2. Generate missing plans with `rnd/skills/create-build-plan/SKILL.md`.
+3. Confirm the plans collectively own each applicable minimum-production-baseline item. Keep execution order as a short session checklist rather than a new coordination system.
+
+### 3. Implement
+
+1. Execute plans with `rnd/skills/implement-build-plan/SKILL.md` in dependency order.
+2. Parallelize only truly independent work when it materially saves time.
+3. Keep contracts, migrations, authorization/tenant rules, and operational signals consistent with the tech spec.
+4. Run focused checks as each plan lands, then the complete CI-equivalent command set and production-runtime smoke check.
+5. Tell delegated plan implementers to defer the QA-choice prompt to this coordinator.
+
+### 4. Choose QA
+
+After implementation, required automated checks, and runtime smoke finish, ask exactly:
+
+`Which post-implementation QA do you want: AI-run manual QA, reusable E2E test code, both, or neither?`
+
+- **AI-run manual QA:** Use `rnd/skills/run-manual-qa-tests/SKILL.md` directly from acceptance criteria.
+- **Reusable E2E test code:** Use `rnd/skills/create-test-cases/SKILL.md`, then `rnd/skills/run-e2e-tests/SKILL.md`.
+- **Both:** Complete both paths.
+- **Neither:** Create no test-case, E2E, or manual-QA artifact; report the automated verification completed.
+
+### 5. Finish
+
+Report delivered behavior, assumptions, production-baseline decisions, exact validation commands, selected/skipped QA, rollback or migration notes, and intentionally deferred work. Leave the repository runnable.
+
+## Fix Loops
+
+- Enter a fix loop for blocking implementation, required-check, runtime, security/tenancy, data/compatibility, or selected-QA failures.
+- Make at most two focused repair-and-verification cycles for the same failure, then ask for help with evidence.
+- Ask before investigating non-blocking debt or expanding the platform.

--- a/overlays/mvp/skills/run-e2e-tests/SKILL.md
+++ b/overlays/mvp/skills/run-e2e-tests/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: run-e2e-tests
+description: Write and run a small reusable MVP E2E suite through production-like runtime and normal tooling.
+---
+
+# Run E2E Tests — MVP
+
+Write durable tests that protect the selected MVP flows and can be rerun by developers or CI without AI.
+
+{{rnd/agents/shared/mvp.md}}
+{{rnd/agents/shared/command-hygiene.md}}
+
+Run this skill only when the user selects **reusable E2E test code** or invokes it directly. Do not use it for the manual-QA-only path.
+
+## Inputs
+
+- A test-case file under `rnd/test_cases/`
+- Relevant tech spec and build plans
+- Implemented code, CI, production Docker/Compose files, startup commands, and existing E2E examples
+
+## Outputs
+
+- E2E tests in the repository's existing location
+- A normal developer command that runs them without AI
+- A short result under `rnd/e2e-results/<feature-id>-e2e-result.md`
+- Normal runner artifacts for failures only
+
+## Workflow
+
+1. Read the selected cases and inspect the existing E2E runner, fixtures, CI jobs, and production startup path.
+2. Reuse the current framework and selector conventions. Do not introduce a second runner. For a browser project with none, use Playwright unless the user chooses another tool; ask before adding a substantial dependency.
+3. Prefer the production image/configuration over a development server when it is reasonably runnable. Start only required services in detached mode and verify health/readiness before tests.
+4. Use deterministic minimal fixtures. Create separate principals or tenants only when a selected authorization/isolation case requires them.
+5. Implement the primary flow first, then only the listed production-boundary cases.
+6. Keep secrets out of test source, output, screenshots, and CI. Use the repository's test-secret or environment convention.
+7. Wire the suite into a normal command. Add it to required CI only when it is deterministic, affordable, and protects a critical release flow; otherwise document the explicit trigger and reason.
+8. Run one representative environment or browser. Cross-browser and scale matrices are out of scope unless requested.
+9. Record the reusable command, cases, status, blocking error, runtime used, and failure artifact paths.
+10. Stop only services started by this workflow.
+
+## Failure Handling
+
+- Classify failures as environment/test method, product behavior, security/tenant boundary, or compatibility/data behavior.
+- Repair a blocking environment or test-method problem at most twice.
+- Return a product failure for a focused implementation fix under the same two-cycle limit.
+- After two unsuccessful attempts at the same failure, ask for help with evidence.
+- Ask before investigating anything that does not block the selected cases.
+
+## Done
+
+Every selected case exists as reusable code and has passed, failed with a focused diagnosis, or stopped at the retry limit. The command is documented, and its CI placement is explicit.

--- a/overlays/mvp/skills/run-manual-qa-tests/SKILL.md
+++ b/overlays/mvp/skills/run-manual-qa-tests/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: run-manual-qa-tests
+description: Exercise selected MVP acceptance criteria against the production-like runtime and report concise evidence.
+---
+
+# Run Manual QA — MVP
+
+Use AI-driven interaction with the production-like system to verify selected acceptance behavior now. This is a live check, not reusable automated test code.
+
+{{rnd/agents/shared/mvp.md}}
+{{rnd/agents/shared/command-hygiene.md}}
+
+## When To Run
+
+Run only after the owning full-control or `implement-feature` workflow asks which QA the user wants and the user selects **AI-run manual QA** or **both**.
+
+Do not require or create a file under `rnd/test_cases/`. Read acceptance criteria directly from the tech spec and completed build plans, or use a focused inline scenario supplied by the user.
+
+## Inputs
+
+- Relevant tech spec and completed build plans, or one inline acceptance/reproduction scenario
+- Production Docker/Compose and runtime/configuration instructions
+- Existing test accounts, tenant fixtures, and non-production secrets when needed
+
+## Output
+
+- A concise report at `rnd/manual-qa-results/<feature-id>-manual-qa-result.md`
+- Failure artifacts only when they materially help diagnosis
+
+## Workflow
+
+1. Extract the primary happy path and only selected, directly relevant security, tenant, compatibility, or recovery edges.
+2. Start the smallest production-like environment in detached mode and confirm health/readiness.
+3. Exercise the real user, API, or CLI boundary. Use distinct authorized/unauthorized or tenant identities only when required by the acceptance criteria.
+4. Confirm externally visible behavior and, when relevant, the expected safe error, migration result, health signal, or structured log without exposing sensitive values.
+5. Record the exact action or command, expected result, observed result, and pass/fail status.
+6. Capture a screenshot, response transcript, or focused log for failures or when it materially clarifies the result.
+7. Write the concise result and stop only services started by this workflow.
+
+## Failure Handling
+
+- Correct a blocking environment or QA-method problem at most twice.
+- Return a product, security/tenant, or compatibility failure for a focused implementation fix under the shared two-cycle limit.
+- After two unsuccessful attempts at the same failure, ask for help with evidence.
+- Ask before investigating warnings or adjacent issues that do not block the acceptance flow.
+
+## Result Format
+
+```markdown
+# Manual QA Result — <feature-id>
+
+- **Environment:** <production-like runtime used>
+- **Verdict:** PASS | FAIL | BLOCKED
+
+## Checks
+
+- `<check>` — PASS | FAIL | BLOCKED
+  - Action: `<command or interaction>`
+  - Expected: <result>
+  - Observed: <result>
+  - Artifact: <path or None>
+
+## Blocking Issue
+
+None | <concise failure and next decision needed>
+```

--- a/overlays/mvp/templates/build_plan.md
+++ b/overlays/mvp/templates/build_plan.md
@@ -1,0 +1,58 @@
+# Build Plan — `<feature-id>-T<n>`
+
+- **Source:** `<tech-spec-path>`
+- **Task:** `T<n> — <title>`
+- **Outcome:** <working, deployable result this plan delivers>
+- **Status:** Draft | Approved | In Progress | Complete
+
+## Scope
+
+- **In:** <required behavior and touched area>
+- **Out:** <explicitly deferred work>
+- **Depends on:** None | `<task or existing contract>`
+
+## Contracts And Non-Obvious Details
+
+- **Consumes:** <input/API/type/state, or None>
+- **Exposes:** <output/API/type/state, or None>
+- **Algorithm/state rule:** <only details needed to avoid incompatible implementations>
+- **Data/migration rule:** <compatibility and rollback detail, or Not applicable>
+
+## Production Baseline
+
+Use `Not applicable — <reason>` instead of adding unused machinery.
+
+- **CI:** <existing/new checks this task must preserve or add>
+- **Runtime/config:** <Dockerfile, Compose dependency, health, config, or secret handling>
+- **Security/auth/tenancy:** <validation, authorization, ownership, and isolation work>
+- **Compatibility:** <existing consumer/data behavior to preserve and migration path>
+- **Operability:** <logs, correlation, health/readiness, or actionable metric>
+
+## Implementation
+
+- [ ] `<path>` — <create/change and the essential requirement>
+- [ ] `<path>` — <create/change and the essential requirement>
+- [ ] Wire the changed pieces through `<boundary>`.
+- [ ] Implement every applicable production-baseline item above.
+
+## Tests And Verification
+
+- [ ] Unit: <happy path behavior>
+- [ ] Unit: <important failure, authorization, or tenant edge>
+- [ ] Boundary/contract: <highest-risk real boundary, or Not applicable with reason>
+- [ ] CI-equivalent checks: <lint/type/test/build/image commands>
+- [ ] Runtime smoke: <production container and health/readiness command, or Not applicable>
+- **Optional QA candidate:** <primary flow plus critical security/tenant/compatibility edge>
+
+## Done When
+
+- [ ] Required behavior is demonstrable.
+- [ ] Focused automated checks pass and are covered by CI.
+- [ ] The applicable production image/runtime builds, starts, and reports healthy.
+- [ ] Applicable security, compatibility, identity/tenancy, and operability decisions are implemented.
+
+After the final implementation plan, the owning workflow asks whether to run AI manual QA, write reusable E2E test code, do both, or do neither.
+
+## Blocking Questions
+
+- None | <decision required before implementation can continue>

--- a/overlays/mvp/templates/tech_spec.md
+++ b/overlays/mvp/templates/tech_spec.md
@@ -1,0 +1,89 @@
+# Technical Specification — <Feature Name>
+
+- **Feature ID:** `<feature-id>`
+- **Source:** Direct requirements, issue, or supplied supporting document
+- **Author:** Engineer
+- **Date:** `<yyyy-mm-dd>`
+- **Status:** Draft | Approved
+
+## 1. Outcome And Scope
+
+### Required behavior
+
+- **FR1:** <observable requirement>
+- **FR2:** <observable requirement>
+
+### Essential constraints
+
+- <constraint that changes the design or production baseline>
+
+### Out of scope
+
+- <explicitly deferred behavior or hardening>
+
+### Assumptions
+
+- <reversible assumption made to keep moving>
+
+## 2. Existing Context
+
+- `<path>` — <what is reused or changed>
+- `<path>` — <relevant existing delivery, runtime, or security pattern>
+
+## 3. Components And Contracts
+
+```mermaid
+flowchart LR
+  user[User or Client] --> app[Application]
+  app --> dependency[Required Dependency]
+```
+
+| Boundary | Contract | Owner |
+|----------|----------|-------|
+| `<caller -> callee>` | `<request/input -> response/output>` | `<component>` |
+
+## 4. Minimum Production Baseline
+
+Use `Not applicable — <reason>` when a concern does not apply. Do not invent a subsystem merely to fill the table.
+
+| Concern | Decision And Minimum Implementation |
+|---------|-------------------------------------|
+| CI | <existing/new workflow and required lint, type, test, build, and image checks> |
+| Runtime and config | <production Dockerfile, required services, health/readiness, environment variables, secret source> |
+| Security | <trust boundaries, validation, authn/authz, sensitive data and error handling> |
+| Identity and tenancy | <public/authenticated/tenant-scoped; ownership and isolation rule> |
+| Compatibility and data | <affected consumers/data, additive or breaking change, migration and rollback> |
+| Operability | <structured logs, correlation, health signals, and only actionable metrics> |
+
+## 5. Non-Obvious Implementation Details
+
+- **Algorithm or state transition:** <only what implementers must agree on>
+- **Data shape and lifecycle:** <essential fields, ownership, retention, or migration>
+- **Failure behavior:** <safe observable response and operational signal>
+- **Deployment or rollback:** <smallest useful release/backout detail>
+
+## 6. Verification
+
+- **Unit:** <new behavior and important failure/authorization case>
+- **Boundary/contract:** <one production-risk boundary to test, or Not applicable with reason>
+- **CI:** <commands/checks that must pass>
+- **Runtime smoke:** <container start plus health/readiness check, or Not applicable>
+- **Optional QA candidates:** <primary flow and any critical security/tenant/compatibility edge>
+- **QA choice:** Ask after implementation; do not decide in the spec.
+
+## 7. Tasks
+
+### T1 — <vertical slice or bounded deliverable>
+
+- **Outcome:** <working, deployable result>
+- **Scope:** <files/components or behavior>
+- **Depends on:** None | T<n>
+- **Consumes/Exposes:** <contract needed by another task, or None>
+- **Production baseline:** <CI/runtime/security/compatibility/operability work owned here>
+- **Acceptance:** <observable result and focused checks>
+
+<!-- Add another task only when separate ownership or dependency ordering is useful. -->
+
+## 8. Blocking Questions
+
+- None | <question whose answer can change behavior, data, a public contract, security, tenancy, or technology>

--- a/overlays/mvp/templates/test_cases.md
+++ b/overlays/mvp/templates/test_cases.md
@@ -1,0 +1,29 @@
+# E2E Test Cases — <Feature Name>
+
+- **Feature ID:** `<feature-id>`
+- **Tech Spec:** `<tech-spec-path>`
+- **Build Plan(s):** `<build-plan-paths>`
+- **Date:** `<yyyy-mm-dd>`
+
+Keep the suite small. Start with the primary production flow and add only directly relevant security, tenant, compatibility, or recovery edges. Usually 1–8 cases are enough.
+
+## `<feature-id>-TC-01` — <primary happy path>
+
+- **Given:** <minimal production-like precondition>
+- **When:** <user/API/CLI action>
+- **Then:** <observable result>
+- **Setup:** <fixture, account, tenant, or container requirement, if any>
+
+## `<feature-id>-TC-02` — <critical boundary case, only if applicable>
+
+- **Given:** <unauthorized, cross-tenant, legacy-consumer, or failure precondition>
+- **When:** <action>
+- **Then:** <safe observable result and preserved contract>
+- **Setup:** <fixture or None>
+
+## Notes
+
+- Map every case to a requirement or production-baseline decision.
+- Omit low-value permutations and speculative scale cases.
+- Prefer stable existing selectors, fixtures, accounts, and runtime commands.
+- Do not duplicate focused unit or boundary tests unless the end-to-end behavior carries distinct risk.


### PR DESCRIPTION
## What changed

- add an independent `mvp` mindset overlay with compact tech-spec, build-plan, implementation, bugfix, reusable E2E, and manual-QA skills
- preserve the prototyping overlay's focused vertical-slice workflow and user-selected QA handoff
- raise the MVP completion bar to the smallest applicable production baseline:
  - deterministic CI and production image checks
  - a production Docker/runtime and explicit configuration/secret handling
  - security, authentication/authorization, and tenant-isolation decisions
  - additive compatibility, migration, and rollback handling where consumers or stored data exist
  - health/readiness, useful structured logs, correlation, and only actionable metrics
- let irrelevant production concerns be marked `Not applicable` with a reason so the workflow does not manufacture boilerplate
- document `mvp` and `prototyping` as alternative mindset overlays whose precedence follows selection order
- add a contract test that verifies both mindset overlays provide their complete override set and have no unresolved template references

## Why

An MVP should retain prototype velocity, but it also needs to be deployable and operable for real users. This overlay keeps planning and implementation compact while making production safety explicit at the boundaries that matter, without turning the beginning of a project into a platform build.

## Developer impact

Select `mvp` after stack overlays. Generated specs and plans stay brief, but they must decide the applicable CI, runtime, security, identity/tenancy, compatibility/data, and operability baseline. Existing project patterns are reused first, and non-applicable concerns require only a short rationale.

## Validation

- `git diff --check`
- `npx jest cli/src/lib/overlays/mindsetOverlays.spec.js --runInBand`
- `npx jest --runInBand`
- 24 test suites passed
- 232 tests passed, 1 skipped

## Stack

This PR is intentionally based on #100 and should be reviewed/merged after it.