### PR TITLE
Fix overlay vendor skill generation

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -58,7 +58,7 @@ Commands:
   - From the project root: `node src/index.js init`
   - If installed globally: `r3nd init` (see installation section)
 
-- `scaffold`: Full project scaffolding — prompts for ordered overlays discovered from the seed repo, copies base seed content plus selected overlay files, and keeps the existing scaffold build plan filenames for LLM execution.
+- `scaffold`: Full project scaffolding — prompts for ordered overlays discovered from the seed repo, resolves them into one effective seed, materializes canonical and vendor files once, and keeps the existing scaffold build plan filenames for LLM execution.
 
 - `analyse`: Analyze repository and app scopes and generate `AGENTS.md` / `CLAUDE.md` files using an LLM agent.
   - Options:

--- a/cli/src/lib/fs/seedCopier.spec.js
+++ b/cli/src/lib/fs/seedCopier.spec.js
@@ -7,6 +7,7 @@ jest.mock('../ui/prompts', () => ({
 }));
 
 const { copyTaskSkills, syncPlatformAsset } = require('./seedCopier');
+const { createEffectiveSeedView } = require('../overlays/overlaySeedService');
 
 describe('seedCopier', () => {
   let tempDir;
@@ -198,5 +199,88 @@ description: Analyze repository context
     expect(generated).toContain('# analyze-repo-context');
     expect(generated).toContain('# Architect Agent');
     expect(generated).toContain('## Codex-Specific Instructions');
+  });
+
+  it('materializes overlaid canonical and vendor skills without fetching the shadowed original', async () => {
+    const tree = [
+      { type: 'blob', path: 'rnd/skills/create-tech-spec/SKILL.md' },
+      { type: 'blob', path: 'rnd/agents/shared/command-hygiene.md' },
+      { type: 'blob', path: 'rnd/vendor/skills/codex.md' },
+      { type: 'blob', path: 'rnd/vendor/skills/claude.md' },
+      { type: 'blob', path: 'overlays/prototyping/skills/create-tech-spec/SKILL.md' },
+      { type: 'blob', path: 'overlays/prototyping/agents/shared/prototyping.md' }
+    ];
+    const fileMap = new Map([
+      ['rnd/skills/create-tech-spec/SKILL.md', Buffer.from('# Original Skill')],
+      ['rnd/agents/shared/command-hygiene.md', Buffer.from('Keep commands focused.')],
+      ['rnd/vendor/skills/codex.md', Buffer.from('## Codex Instructions')],
+      ['rnd/vendor/skills/claude.md', Buffer.from('## Claude Instructions')],
+      ['overlays/prototyping/skills/create-tech-spec/SKILL.md', Buffer.from(`# Prototype Skill
+
+{{rnd/agents/shared/prototyping.md}}
+{{rnd/agents/shared/command-hygiene.md}}
+`)],
+      ['overlays/prototyping/agents/shared/prototyping.md', Buffer.from('Prototype policy.')]
+    ]);
+    const githubClient = {
+      fetchRaw: jest.fn(async remotePath => {
+        if (!fileMap.has(remotePath)) {
+          throw new Error(`Unexpected fetch: ${remotePath}`);
+        }
+        return fileMap.get(remotePath);
+      })
+    };
+    const effectiveSeed = createEffectiveSeedView(tree, githubClient, 'rnd', ['prototyping']);
+
+    await copyTaskSkills(
+      tempDir,
+      effectiveSeed.tree,
+      effectiveSeed.githubClient,
+      'r3nd',
+      'rnd',
+      { nonInteractive: true, overwriteExisting: true }
+    );
+
+    for (const vendor of ['codex', 'claude']) {
+      await syncPlatformAsset(
+        tempDir,
+        effectiveSeed.tree,
+        effectiveSeed.githubClient,
+        {
+          key: vendor,
+          label: `${vendor} skills`,
+          assetType: 'generated-skill',
+          vendor,
+          outputPath: `.${vendor}/skills`
+        },
+        'r3nd',
+        'rnd',
+        { nonInteractive: true, overwriteExisting: true }
+      );
+    }
+
+    const canonical = await fs.readFile(
+      path.join(tempDir, 'r3nd', 'skills', 'create-tech-spec', 'SKILL.md'),
+      'utf-8'
+    );
+    const codex = await fs.readFile(
+      path.join(tempDir, '.codex', 'skills', 'create-tech-spec', 'SKILL.md'),
+      'utf-8'
+    );
+    const claude = await fs.readFile(
+      path.join(tempDir, '.claude', 'skills', 'create-tech-spec', 'SKILL.md'),
+      'utf-8'
+    );
+
+    expect(canonical).toContain('# Prototype Skill');
+    expect(canonical).toContain('Prototype policy.');
+    expect(codex).toContain('# Prototype Skill');
+    expect(codex).toContain('## Codex Instructions');
+    expect(claude).toContain('# Prototype Skill');
+    expect(claude).toContain('## Claude Instructions');
+    expect(canonical).not.toContain('# Original Skill');
+    expect(codex).not.toContain('# Original Skill');
+    expect(claude).not.toContain('# Original Skill');
+    expect(githubClient.fetchRaw).not.toHaveBeenCalledWith('rnd/skills/create-tech-spec/SKILL.md');
   });
 });

--- a/cli/src/lib/initService.js
+++ b/cli/src/lib/initService.js
@@ -15,6 +15,7 @@ const {
 const {
   fetchSeedSpecDirName,
   discoverAvailableOverlays,
+  createEffectiveSeedView,
   applySelectedOverlays
 } = require('./overlays/overlaySeedService');
 const { askInitOptions, askOverlays, askSeedRepo, askSpecDirName } = require('./ui/prompts');
@@ -141,33 +142,35 @@ async function runInit(opts = {}, deps = {}) {
   const currentOverlays = await configManager.getOverlays();
   const selectedOverlays = await askOverlays(currentOverlays, availableOverlays, nonInteractive);
   await configManager.set('overlays', selectedOverlays);
+  const effectiveSeed = createEffectiveSeedView(tree, githubClient, seedSpecDirName, selectedOverlays);
 
   // Copy common files (gitignore)
   await copyCommonFiles(cwd, tree, githubClient, specDirName, { nonInteractive });
 
-  // Copy shared agents from seed repo
-  await copyAgentPersonas(cwd, tree, githubClient, specDirName, seedSpecDirName, { nonInteractive });
+  // Materialize effective shared agents after overlay precedence is resolved
+  await copyAgentPersonas(cwd, effectiveSeed.tree, effectiveSeed.githubClient, specDirName, seedSpecDirName, { nonInteractive });
 
-  // Copy canonical task skills from seed repo as fully composed local files
-  await copyTaskSkills(cwd, tree, githubClient, specDirName, seedSpecDirName, { nonInteractive });
+  // Materialize effective canonical task skills as fully composed local files
+  await copyTaskSkills(cwd, effectiveSeed.tree, effectiveSeed.githubClient, specDirName, seedSpecDirName, { nonInteractive });
 
-  // Copy base build plans from seed repo
-  await copyBuildPlans(cwd, tree, githubClient, specDirName, seedSpecDirName, { nonInteractive });
+  // Materialize effective build plans
+  await copyBuildPlans(cwd, effectiveSeed.tree, effectiveSeed.githubClient, specDirName, seedSpecDirName, { nonInteractive });
 
   for (const assetKey of selectedOptions) {
     const asset = getPlatformAsset(assetKey);
     if (!asset) {
       continue;
     }
-    await syncPlatformAsset(cwd, tree, githubClient, asset, specDirName, seedSpecDirName, { nonInteractive });
+    await syncPlatformAsset(cwd, effectiveSeed.tree, effectiveSeed.githubClient, asset, specDirName, seedSpecDirName, { nonInteractive });
   }
 
   // Also copy templates if any option was selected
-  await copyTemplates(cwd, tree, githubClient, specDirName, seedSpecDirName, { nonInteractive });
+  await copyTemplates(cwd, effectiveSeed.tree, effectiveSeed.githubClient, specDirName, seedSpecDirName, { nonInteractive });
 
-  await applySelectedOverlays(cwd, tree, githubClient, specDirName, seedSpecDirName, selectedOverlays, {
+  await applySelectedOverlays(cwd, effectiveSeed.tree, effectiveSeed.githubClient, specDirName, seedSpecDirName, selectedOverlays, {
     nonInteractive,
-    overwriteExisting: true
+    overwriteExisting: true,
+    skipSpecSubdirs: ['agents', 'skills', 'templates', 'build_plans']
   });
 
   logger.info('\nInit complete.');

--- a/cli/src/lib/initService.spec.js
+++ b/cli/src/lib/initService.spec.js
@@ -27,6 +27,7 @@ jest.mock('./fs/seedCopier', () => ({
 jest.mock('./overlays/overlaySeedService', () => ({
   fetchSeedSpecDirName: jest.fn().mockResolvedValue('rnd'),
   discoverAvailableOverlays: jest.fn().mockReturnValue(['api', 'vue']),
+  createEffectiveSeedView: jest.fn((tree, githubClient) => ({ tree, githubClient })),
   applySelectedOverlays: jest.fn().mockResolvedValue(undefined)
 }));
 
@@ -67,7 +68,11 @@ describe('initService', () => {
         'r3nd',
         'rnd',
         ['api', 'vue'],
-        { nonInteractive: false, overwriteExisting: true }
+        {
+          nonInteractive: false,
+          overwriteExisting: true,
+          skipSpecSubdirs: ['agents', 'skills', 'templates', 'build_plans']
+        }
       );
     });
   });

--- a/cli/src/lib/overlays/overlaySeedService.js
+++ b/cli/src/lib/overlays/overlaySeedService.js
@@ -80,6 +80,66 @@ function createOverlayAliases(remotePath, overlayName, specDirName) {
   return Array.from(aliases);
 }
 
+function getOverlaySpecSourcePath(remotePath, overlayName, seedSpecDirName) {
+  const overlayRoot = `overlays/${overlayName}/`;
+  if (!remotePath.startsWith(overlayRoot)) {
+    return null;
+  }
+
+  const relativePath = remotePath.slice(overlayRoot.length);
+  const segments = relativePath.split('/');
+  const topLevelDir = segments[0];
+  const nestedPath = segments.slice(1).join('/');
+
+  if (!nestedPath || !OVERLAY_SPEC_SUBDIR_DESTINATIONS[topLevelDir]) {
+    return null;
+  }
+
+  return `${seedSpecDirName}/${OVERLAY_SPEC_SUBDIR_DESTINATIONS[topLevelDir]}/${nestedPath}`;
+}
+
+/**
+ * Build a seed view where selected overlay files replace their canonical seed
+ * paths before anything is copied or generated. Later overlays have precedence.
+ */
+function createEffectiveSeedView(tree, githubClient, seedSpecDirName, overlays) {
+  const selectedOverlays = Array.isArray(overlays) ? overlays.filter(Boolean) : [];
+  const effectiveTree = Array.isArray(tree) ? [...tree] : [];
+  const knownPaths = new Set(effectiveTree.map(item => item.path));
+  const sourceOverrides = new Map();
+
+  for (const overlayName of selectedOverlays) {
+    for (const item of listRemoteFiles(effectiveTree, `overlays/${overlayName}/`)) {
+      const canonicalPath = getOverlaySpecSourcePath(item.path, overlayName, seedSpecDirName);
+      if (!canonicalPath) {
+        continue;
+      }
+
+      sourceOverrides.set(canonicalPath, item.path);
+      if (!knownPaths.has(canonicalPath)) {
+        effectiveTree.push({ type: 'blob', path: canonicalPath });
+        knownPaths.add(canonicalPath);
+      }
+    }
+  }
+
+  const rawFileCache = new Map();
+  const effectiveGithubClient = {
+    async fetchRaw(remotePath) {
+      const sourcePath = sourceOverrides.get(remotePath) || remotePath;
+      if (!rawFileCache.has(sourcePath)) {
+        rawFileCache.set(sourcePath, Promise.resolve().then(() => githubClient.fetchRaw(sourcePath)));
+      }
+      return rawFileCache.get(sourcePath);
+    }
+  };
+
+  return {
+    tree: effectiveTree,
+    githubClient: effectiveGithubClient
+  };
+}
+
 async function fetchSeedSpecDirName(githubClient) {
   try {
     const configBuffer = await githubClient.fetchRaw('r3nd.yaml');
@@ -127,8 +187,18 @@ async function buildBaseTemplateCache(tree, githubClient, specDirName, seedSpecD
   return fileCache;
 }
 
-async function buildOverlayBuffers(tree, githubClient, overlayName) {
-  const overlayFiles = listRemoteFiles(tree, `overlays/${overlayName}/`);
+async function buildOverlayBuffers(tree, githubClient, overlayName, skipSpecSubdirs = []) {
+  const skipped = new Set(skipSpecSubdirs);
+  const availableOverlayFiles = listRemoteFiles(tree, `overlays/${overlayName}/`);
+  if (availableOverlayFiles.length === 0) {
+    logger.warn(`  No files found for overlay "${overlayName}".`);
+  }
+
+  const overlayFiles = availableOverlayFiles.filter(file => {
+    const relativePath = file.path.slice(`overlays/${overlayName}/`.length);
+    const topLevelDir = relativePath.split('/')[0];
+    return !skipped.has(topLevelDir);
+  });
   const buffers = new Map();
 
   for (const file of overlayFiles) {
@@ -142,12 +212,11 @@ async function buildOverlayBuffers(tree, githubClient, overlayName) {
   return { overlayFiles, buffers };
 }
 
-async function applyOverlay(cwd, tree, githubClient, specDirName, seedSpecDirName, overlayName, baseTemplateCache, { nonInteractive = false, overwriteExisting = true } = {}) {
+async function applyOverlay(cwd, tree, githubClient, specDirName, seedSpecDirName, overlayName, baseTemplateCache, { nonInteractive = false, overwriteExisting = true, skipSpecSubdirs = [] } = {}) {
   logger.info(`\n📦 Applying overlay: ${overlayName}`);
 
-  const { overlayFiles, buffers } = await buildOverlayBuffers(tree, githubClient, overlayName);
+  const { overlayFiles, buffers } = await buildOverlayBuffers(tree, githubClient, overlayName, skipSpecSubdirs);
   if (overlayFiles.length === 0) {
-    logger.warn(`  No files found for overlay "${overlayName}".`);
     return;
   }
 
@@ -201,6 +270,17 @@ async function applySelectedOverlays(cwd, tree, githubClient, specDirName, seedS
   const selectedOverlays = Array.isArray(overlays) ? overlays.filter(Boolean) : [];
   if (selectedOverlays.length === 0) {
     logger.info('\n📦 No overlays selected.');
+    return;
+  }
+
+  const skipped = new Set(options.skipSpecSubdirs || []);
+  const hasFilesToApply = selectedOverlays.some(overlayName =>
+    listRemoteFiles(tree, `overlays/${overlayName}/`).some(file => {
+      const relativePath = file.path.slice(`overlays/${overlayName}/`.length);
+      return !skipped.has(relativePath.split('/')[0]);
+    })
+  );
+  if (!hasFilesToApply) {
     return;
   }
 
@@ -268,6 +348,7 @@ async function ensureSpecDirectories(cwd, specDirName, { createRndInstructions =
 module.exports = {
   fetchSeedSpecDirName,
   discoverAvailableOverlays,
+  createEffectiveSeedView,
   applySelectedOverlays,
   ensureMandatorySeedFiles,
   ensureSpecDirectories,

--- a/cli/src/lib/overlays/overlaySeedService.spec.js
+++ b/cli/src/lib/overlays/overlaySeedService.spec.js
@@ -37,6 +37,7 @@ jest.mock('../fs/seedCopier', () => {
 
 const {
   discoverAvailableOverlays,
+  createEffectiveSeedView,
   applySelectedOverlays,
   getOverlayDestinationForPath
 } = require('./overlaySeedService');
@@ -66,6 +67,30 @@ describe('overlaySeedService', () => {
       expect(
         getOverlayDestinationForPath('overlays/api/templates/feature.md', 'api', 'r3nd')
       ).toBe(path.join('r3nd', 'templates', 'feature.md'));
+    });
+  });
+
+  describe('createEffectiveSeedView', () => {
+    it('replaces canonical paths in memory with later overlay sources', async () => {
+      const tree = [
+        { type: 'blob', path: 'rnd/skills/example/SKILL.md' },
+        { type: 'blob', path: 'overlays/one/skills/example/SKILL.md' },
+        { type: 'blob', path: 'overlays/two/skills/example/SKILL.md' },
+        { type: 'blob', path: 'overlays/two/skills/new-task/SKILL.md' }
+      ];
+      const githubClient = {
+        fetchRaw: jest.fn(async remotePath => Buffer.from(remotePath))
+      };
+
+      const effectiveSeed = createEffectiveSeedView(tree, githubClient, 'rnd', ['one', 'two']);
+
+      await expect(effectiveSeed.githubClient.fetchRaw('rnd/skills/example/SKILL.md'))
+        .resolves.toEqual(Buffer.from('overlays/two/skills/example/SKILL.md'));
+      expect(effectiveSeed.tree).toContainEqual({
+        type: 'blob',
+        path: 'rnd/skills/new-task/SKILL.md'
+      });
+      expect(githubClient.fetchRaw).not.toHaveBeenCalledWith('rnd/skills/example/SKILL.md');
     });
   });
 
@@ -106,6 +131,28 @@ describe('overlaySeedService', () => {
         .resolves.toBe('overlay two\n');
       await expect(fs.readFile(path.join(tempDir, 'docs', 'guide.md'), 'utf-8'))
         .resolves.toBe('# Guide\n');
+    });
+
+    it('can skip spec files already materialized from the effective seed', async () => {
+      const files = new Map([
+        ['rnd/templates/base.md', Buffer.from('base template\n')],
+        ['overlays/one/templates/shared.md', Buffer.from('overlay template\n')],
+        ['overlays/one/instructions/docs/guide.md', Buffer.from('# Guide\n')]
+      ]);
+      const tree = Array.from(files.keys()).map(filePath => ({ type: 'blob', path: filePath }));
+      const githubClient = {
+        fetchRaw: jest.fn(async remotePath => files.get(remotePath))
+      };
+
+      await applySelectedOverlays(tempDir, tree, githubClient, 'r3nd', 'rnd', ['one'], {
+        overwriteExisting: true,
+        skipSpecSubdirs: ['templates']
+      });
+
+      await expect(fs.access(path.join(tempDir, 'r3nd', 'templates', 'shared.md'))).rejects.toThrow();
+      await expect(fs.readFile(path.join(tempDir, 'docs', 'guide.md'), 'utf-8'))
+        .resolves.toBe('# Guide\n');
+      expect(githubClient.fetchRaw).not.toHaveBeenCalledWith('overlays/one/templates/shared.md');
     });
   });
 });

--- a/cli/src/lib/scaffoldService.js
+++ b/cli/src/lib/scaffoldService.js
@@ -14,6 +14,7 @@ const {
 const { 
   fetchSeedSpecDirName, 
   discoverAvailableOverlays,
+  createEffectiveSeedView,
   applySelectedOverlays,
   ensureMandatorySeedFiles, 
   ensureSpecDirectories 
@@ -80,36 +81,38 @@ async function runScaffold(opts = {}, deps = {}) {
   const currentOverlays = await configManager.getOverlays();
   const selectedOverlays = await askOverlays(currentOverlays, availableOverlays, nonInteractive);
   await configManager.set('overlays', selectedOverlays);
+  const effectiveSeed = createEffectiveSeedView(tree, githubClient, seedSpecDirName, selectedOverlays);
 
   // Copy common files (gitignore)
   await copyCommonFiles(cwd, tree, githubClient, specDirName, { nonInteractive });
 
-  // Copy shared agents
-  await copyAgentPersonas(cwd, tree, githubClient, specDirName, seedSpecDirName, { nonInteractive });
+  // Materialize effective shared agents after overlay precedence is resolved
+  await copyAgentPersonas(cwd, effectiveSeed.tree, effectiveSeed.githubClient, specDirName, seedSpecDirName, { nonInteractive });
 
   // Copy testing instructions to spec-dir/instructions
   await copyTestingInstructions(cwd, tree, githubClient, specDirName, seedSpecDirName, { nonInteractive });
 
-  // Copy canonical task skills from seed repo as fully composed local files
-  await copyTaskSkills(cwd, tree, githubClient, specDirName, seedSpecDirName, { nonInteractive });
+  // Materialize effective canonical task skills as fully composed local files
+  await copyTaskSkills(cwd, effectiveSeed.tree, effectiveSeed.githubClient, specDirName, seedSpecDirName, { nonInteractive });
 
-  // Copy base build plans from seed repo
-  await copyBuildPlans(cwd, tree, githubClient, specDirName, seedSpecDirName, { nonInteractive });
+  // Materialize effective build plans
+  await copyBuildPlans(cwd, effectiveSeed.tree, effectiveSeed.githubClient, specDirName, seedSpecDirName, { nonInteractive });
 
   for (const assetKey of selectedOptions) {
     const asset = getPlatformAsset(assetKey);
     if (!asset) {
       continue;
     }
-    await syncPlatformAsset(cwd, tree, githubClient, asset, specDirName, seedSpecDirName, { nonInteractive });
+    await syncPlatformAsset(cwd, effectiveSeed.tree, effectiveSeed.githubClient, asset, specDirName, seedSpecDirName, { nonInteractive });
   }
 
   // Copy templates
-  await copyTemplates(cwd, tree, githubClient, specDirName, seedSpecDirName, { nonInteractive });
+  await copyTemplates(cwd, effectiveSeed.tree, effectiveSeed.githubClient, specDirName, seedSpecDirName, { nonInteractive });
 
-  await applySelectedOverlays(cwd, tree, githubClient, specDirName, seedSpecDirName, selectedOverlays, {
+  await applySelectedOverlays(cwd, effectiveSeed.tree, effectiveSeed.githubClient, specDirName, seedSpecDirName, selectedOverlays, {
     nonInteractive,
-    overwriteExisting: true
+    overwriteExisting: true,
+    skipSpecSubdirs: ['agents', 'skills', 'templates', 'build_plans']
   });
 
   // Ensure spec directories exist (conditionally create rnd/instructions)

--- a/cli/src/lib/scaffoldService.spec.js
+++ b/cli/src/lib/scaffoldService.spec.js
@@ -30,6 +30,7 @@ jest.mock('./fs/seedCopier', () => ({
 jest.mock('./overlays/overlaySeedService', () => ({
   fetchSeedSpecDirName: jest.fn().mockResolvedValue('rnd'),
   discoverAvailableOverlays: jest.fn().mockReturnValue(['api', 'vue']),
+  createEffectiveSeedView: jest.fn((tree, githubClient) => ({ tree, githubClient })),
   applySelectedOverlays: jest.fn().mockResolvedValue(undefined),
   ensureMandatorySeedFiles: jest.fn().mockResolvedValue(undefined),
   ensureSpecDirectories: jest.fn().mockResolvedValue(undefined)

--- a/cli/src/lib/updateService.js
+++ b/cli/src/lib/updateService.js
@@ -13,6 +13,7 @@ const {
 } = require('./fs/seedCopier');
 const {
   fetchSeedSpecDirName,
+  createEffectiveSeedView,
   applySelectedOverlays
 } = require('./overlays/overlaySeedService');
 const {
@@ -58,16 +59,20 @@ async function runUpdate(opts = {}, deps = {}) {
   const seedSpecDirName = await fetchSeedSpecDirName(githubClient);
   const selectedPlatformAssets = normalizePlatformAssetSelection(selectedOptions);
   const selectedOverlays = await configManager.getOverlays();
+  const effectiveSeed = createEffectiveSeedView(tree, githubClient, seedSpecDirName, selectedOverlays);
+  const materializedOverlaySubdirs = ['agents', 'build_plans'];
 
-  await copyAgentPersonas(cwd, tree, githubClient, specDirName, seedSpecDirName, { overwriteExisting: true });
-  await copyBuildPlans(cwd, tree, githubClient, specDirName, seedSpecDirName, { overwriteExisting: true });
+  await copyAgentPersonas(cwd, effectiveSeed.tree, effectiveSeed.githubClient, specDirName, seedSpecDirName, { overwriteExisting: true });
+  await copyBuildPlans(cwd, effectiveSeed.tree, effectiveSeed.githubClient, specDirName, seedSpecDirName, { overwriteExisting: true });
 
   if (selectedOptions.includes('templates')) {
-    await copyTemplates(cwd, tree, githubClient, specDirName, seedSpecDirName, { overwriteExisting: true });
+    await copyTemplates(cwd, effectiveSeed.tree, effectiveSeed.githubClient, specDirName, seedSpecDirName, { overwriteExisting: true });
+    materializedOverlaySubdirs.push('templates');
   }
 
   if (selectedOptions.includes('skills')) {
-    await copyTaskSkills(cwd, tree, githubClient, specDirName, seedSpecDirName, { overwriteExisting: true });
+    await copyTaskSkills(cwd, effectiveSeed.tree, effectiveSeed.githubClient, specDirName, seedSpecDirName, { overwriteExisting: true });
+    materializedOverlaySubdirs.push('skills');
   }
 
   for (const assetKey of selectedPlatformAssets) {
@@ -75,11 +80,12 @@ async function runUpdate(opts = {}, deps = {}) {
     if (!asset) {
       continue;
     }
-    await syncPlatformAsset(cwd, tree, githubClient, asset, specDirName, seedSpecDirName, { overwriteExisting: true });
+    await syncPlatformAsset(cwd, effectiveSeed.tree, effectiveSeed.githubClient, asset, specDirName, seedSpecDirName, { overwriteExisting: true });
   }
 
-  await applySelectedOverlays(cwd, tree, githubClient, specDirName, seedSpecDirName, selectedOverlays, {
-    overwriteExisting: true
+  await applySelectedOverlays(cwd, effectiveSeed.tree, effectiveSeed.githubClient, specDirName, seedSpecDirName, selectedOverlays, {
+    overwriteExisting: true,
+    skipSpecSubdirs: materializedOverlaySubdirs
   });
 
   logger.info('\nUpdate complete.');

--- a/cli/src/lib/updateService.spec.js
+++ b/cli/src/lib/updateService.spec.js
@@ -26,6 +26,7 @@ jest.mock('./fs/seedCopier', () => ({
 
 jest.mock('./overlays/overlaySeedService', () => ({
   fetchSeedSpecDirName: jest.fn().mockResolvedValue('rnd'),
+  createEffectiveSeedView: jest.fn((tree, githubClient) => ({ tree, githubClient })),
   applySelectedOverlays: jest.fn().mockResolvedValue(undefined)
 }));
 
@@ -88,7 +89,10 @@ describe('updateService', () => {
         'r3nd',
         'rnd',
         ['api', 'vue'],
-        { overwriteExisting: true }
+        {
+          overwriteExisting: true,
+          skipSpecSubdirs: ['agents', 'build_plans', 'templates', 'skills']
+        }
       );
     });
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,8 +75,8 @@ Current behavior from the CLI implementation:
 - prompts for `spec-dir-name`
 - lets you choose platform asset families
 - fetches the seed tree from GitHub
-- copies common files, task skills, agent personas, templates, and base build plans
-- applies selected overlays
+- resolves selected overlays over the base seed in precedence order
+- materializes common files, effective task skills, agent personas, templates, build plans, and selected vendor assets
 - writes configuration to `r3nd.yaml`
 
 Command:
@@ -99,10 +99,10 @@ Current behavior from the CLI implementation:
 
 - initializes Git if needed
 - can add `origin` during setup
-- copies the same core seed content as `init`
+- materializes the same effective seed content as `init`
 - also copies testing instructions
 - ensures spec directories exist
-- applies selected overlays
+- materializes root-scoped overlay instructions
 - can optionally run scaffold build plans through a supported agent backend
 
 Command:


### PR DESCRIPTION
## What changed

- Resolve ordered overlays into one effective in-memory seed before materialization.
- Generate canonical skills and selected vendor skills from the same effective content.
- Avoid fetching and writing shadowed base files before replacing them.
- Apply the behavior consistently across `init`, `scaffold`, and `update`.
- Add regression coverage for overlaid `.codex` and `.claude` skill outputs and update the workflow documentation.

## Why

Vendor skill directories were generated from base canonical skills before overlays were applied. The canonical `r3nd/skills` files were then overwritten by the overlay, leaving vendor outputs stale and doing redundant work.

## Impact

Selected vendor outputs now match the effective overlaid canonical skills. Later overlays retain precedence, overlay-added canonical paths are supported, and shadowed originals are not fetched or materialized first.

## Validation

- `cd cli && npx jest --runInBand`
- 23 test suites passed
- 230 tests passed, 1 skipped
- `git diff --check`